### PR TITLE
Replace "DipoleELFF" with "Dipole" in configuration for the NievesQELCCPXSec model

### DIFF
--- a/config/G18_10a/ModelConfiguration.xml
+++ b/config/G18_10a/ModelConfiguration.xml
@@ -66,7 +66,7 @@ STFC, Rutherford Appleton Laboratory
 <!-- New Nieves QE model   -->
 
 
-  <param type="alg" name="XSecModel@genie::EventGenerator/QEL-CC">         genie::NievesQELCCPXSec/DipoleELFF         </param>
+  <param type="alg" name="XSecModel@genie::EventGenerator/QEL-CC">         genie::NievesQELCCPXSec/Dipole         </param>
 
   <!-- <param type="alg" name="XSecModel@genie::EventGenerator/QEL-CC">         genie::LwlynSmithQELCCPXSec/Dipole   </param> -->
   <param type="alg" name="XSecModel@genie::EventGenerator/QEL-NC">         genie::AhrensNCELPXSec/Default          </param>

--- a/config/G18_10b/ModelConfiguration.xml
+++ b/config/G18_10b/ModelConfiguration.xml
@@ -66,7 +66,7 @@ STFC, Rutherford Appleton Laboratory
 <!-- New Nieves QE model   -->
 
 
-  <param type="alg" name="XSecModel@genie::EventGenerator/QEL-CC">         genie::NievesQELCCPXSec/DipoleELFF         </param>
+  <param type="alg" name="XSecModel@genie::EventGenerator/QEL-CC">         genie::NievesQELCCPXSec/Dipole         </param>
 
   <!-- <param type="alg" name="XSecModel@genie::EventGenerator/QEL-CC">         genie::LwlynSmithQELCCPXSec/Dipole   </param> -->
   <param type="alg" name="XSecModel@genie::EventGenerator/QEL-NC">         genie::AhrensNCELPXSec/Default          </param>

--- a/config/NievesQELCCPXSec.xml
+++ b/config/NievesQELCCPXSec.xml
@@ -45,7 +45,7 @@ IntegralNuclearInfluenceCutoffEnergy double   Yes                               
   </param_set>
 
 
-  <param_set name="DipoleELFF">
+  <param_set name="Dipole">
      <param type="alg"  name="FormFactorsAlg">  genie::LwlynSmithFFCC/Dipole  </param>
 
   </param_set>


### PR DESCRIPTION
As discussed with @dytman and @nusense today, the Nieves CCQE model uses the name "DipoleELFF" for its dipole form factor configuration instead of "Dipole," which is used by other models and is assumed to be present by some existing reweight calculators. This pull request corrects the discrepancy.