### PR TITLE
Phase space fix for differential xsec stored by QELEventGenerator

### DIFF
--- a/src/Physics/QuasiElastic/EventGen/QELEventGenerator.cxx
+++ b/src/Physics/QuasiElastic/EventGen/QELEventGenerator.cxx
@@ -318,6 +318,15 @@ void QELEventGenerator::ProcessEventRecord(GHepRecord * evrec) const
 
         // If the generated kinematics are accepted, finish-up module's job
         if(accept) {
+
+            // Stored differential cross section uses kPSQ2fE phase space,
+            // but xsec as calculated above does not match. We therefore
+            // recalculate the differential cross section for kPSQ2fE here.
+            // -- S. Gardiner
+            // set the cross section for the selected kinematics
+            double stored_xsec = fXSecModel->XSec(interaction, kPSQ2fE);
+            evrec->SetDiffXSec(stored_xsec,kPSQ2fE);
+
             double gQ2 = interaction->KinePtr()->Q2(false);
             LOG("QELEvent", pINFO) << "*Selected* Q^2 = " << gQ2 << " GeV^2";
 
@@ -361,9 +370,6 @@ void QELEventGenerator::ProcessEventRecord(GHepRecord * evrec) const
             interaction->KinePtr()->Setx (gx,  true);
             interaction->KinePtr()->Sety (gy,  true);
             interaction->KinePtr()->ClearRunningValues();
-
-            // set the cross section for the selected kinematics
-            evrec->SetDiffXSec(xsec,kPSQ2fE);
 
             TLorentzVector lepton(interaction->KinePtr()->FSLeptonP4());
             TLorentzVector outNucleon(interaction->KinePtr()->HadSystP4());


### PR DESCRIPTION
Currently, the differential cross section stored in the event record by QELEventGenerator is claimed to be in the kPSQ2fE phase space, but checks performed while reweighting MaCCQE demonstrate that this is not the case. This leads to unphysically large systematic errors in the GReWeightNuXSecCCQE calculator. The problem is resolved by storing the correct xsec value in this phase space.