### PR TITLE
Fix radius issue in NewQELXSec

### DIFF
--- a/src/Physics/QuasiElastic/XSection/NewQELXSec.h
+++ b/src/Physics/QuasiElastic/XSection/NewQELXSec.h
@@ -47,6 +47,9 @@ namespace utils {
        double DoEval(const double* xin) const;
        ROOT::Math::IBaseFunctionMultiDim* Clone(void) const;
 
+       Interaction* GetInteractionPtr();
+       const Interaction& GetInteraction() const;
+
      private:
        const XSecAlgorithmI* fXSecModel;
        const NuclearModelI* fNuclModel;


### PR DESCRIPTION
The NewQELXSec class fails to vary the hit nucleon radius during spline integration. This problem arises because the input Interaction object is copied twice, and the radius is updated in the first copy instead of the second copy used during numerical integration. This leads to an artificial suppression of the QE cross section near threshold for tunes using the local Fermi gas model. The problem occurs solely during spline integration, i.e., the radius is varied correctly in QELEventGenerator.

This pull request fixes the problem by changing NewQELXSec to vary the radius in the correct Interaction object.