### PR TITLE
Tunename in ntpheader

### DIFF
--- a/src/Framework/Ntuple/LinkDef.h
+++ b/src/Framework/Ntuple/LinkDef.h
@@ -6,7 +6,7 @@
 
 #pragma link C++ namespace genie;
 
-#pragma link C++ class genie::NtpMCTreeHeader;
+#pragma link C++ class genie::NtpMCTreeHeader+;
 #pragma link C++ class genie::NtpMCDTime;
 #pragma link C++ class genie::NtpMCJobEnv;
 #pragma link C++ class genie::NtpMCJobConfig;

--- a/src/Framework/Ntuple/NtpMCTreeHeader.cxx
+++ b/src/Framework/Ntuple/NtpMCTreeHeader.cxx
@@ -60,13 +60,17 @@ void NtpMCTreeHeader::PrintToStream(ostream & stream) const
 {
   string sformat = NtpMCFormat::AsString(this->format);
   string scvstag = this->cvstag.GetString().Data();
-  string stune   = this->tune.GetString().Data();
+  string stune       = this->tune.GetString().Data();
+  string stuneDir    = this->tuneDir.GetString().Data();
+  string scustomDirs = this->customDirs.GetString().Data();
 
   stream << "Tree Header Info:"                     << endl
          << "MC run number     -> " << this->runnu  << endl
          << "NtpRecord Format  -> " << sformat      << endl
          << "GENIE CVS Vrs Nu  -> " << scvstag      << endl
          << "GENIE tune name   -> " << stune        << endl
+         << "tune directory    -> " << stuneDir     << endl
+         << "custom directories-> " << scustomDirs  << endl
          << "File generated at -> " << this->datime << endl;
 }
 //____________________________________________________________________________
@@ -74,9 +78,11 @@ void NtpMCTreeHeader::Copy(const NtpMCTreeHeader & hdr)
 {
   this->format = hdr.format;
   this->cvstag.SetString(hdr.cvstag.GetString().Data());
-  this->tune.SetString(hdr.tune.GetString().Data());
   this->datime.Copy(hdr.datime);
   this->runnu  = hdr.runnu;
+  this->tune.SetString(hdr.tune.GetString().Data());
+  this->tuneDir.SetString(hdr.tuneDir.GetString().Data());
+  this->customDirs.SetString(hdr.customDirs.GetString().Data());
 }
 //____________________________________________________________________________
 void NtpMCTreeHeader::Init(void)
@@ -96,11 +102,15 @@ void NtpMCTreeHeader::Init(void)
   }
 
   string tunename("unknown");
+  string tuneDir("unknown");
+  string customDirs("");
 
   this->format = kNFUndefined;
   this->cvstag.SetString(version.c_str());
-  this->tune.SetString(tunename.c_str());
   this->datime.Now();
   this->runnu  = 0;
+  this->tune.SetString(tunename.c_str());
+  this->tuneDir.SetString(tuneDir.c_str());
+  this->customDirs.SetString(customDirs.c_str());
 }
 //____________________________________________________________________________

--- a/src/Framework/Ntuple/NtpMCTreeHeader.cxx
+++ b/src/Framework/Ntuple/NtpMCTreeHeader.cxx
@@ -60,11 +60,13 @@ void NtpMCTreeHeader::PrintToStream(ostream & stream) const
 {
   string sformat = NtpMCFormat::AsString(this->format);
   string scvstag = this->cvstag.GetString().Data();
+  string stune   = this->tune.GetString().Data();
 
   stream << "Tree Header Info:"                     << endl
          << "MC run number     -> " << this->runnu  << endl
          << "NtpRecord Format  -> " << sformat      << endl
          << "GENIE CVS Vrs Nu  -> " << scvstag      << endl
+         << "GENIE tune name   -> " << stune        << endl
          << "File generated at -> " << this->datime << endl;
 }
 //____________________________________________________________________________
@@ -72,6 +74,7 @@ void NtpMCTreeHeader::Copy(const NtpMCTreeHeader & hdr)
 {
   this->format = hdr.format;
   this->cvstag.SetString(hdr.cvstag.GetString().Data());
+  this->tune.SetString(hdr.tune.GetString().Data());
   this->datime.Copy(hdr.datime);
   this->runnu  = hdr.runnu;
 }
@@ -79,7 +82,7 @@ void NtpMCTreeHeader::Copy(const NtpMCTreeHeader & hdr)
 void NtpMCTreeHeader::Init(void)
 {
   string version;
-  string genie_path = gSystem->Getenv("GENIE");   
+  string genie_path = gSystem->Getenv("GENIE");
   string filename   = genie_path + "/VERSION";
   bool vrs_file_found = ! (gSystem->AccessPathName(filename.c_str()));
   if (!vrs_file_found) {
@@ -92,8 +95,11 @@ void NtpMCTreeHeader::Init(void)
     gvinp.close();
   }
 
+  string tunename("unknown");
+
   this->format = kNFUndefined;
   this->cvstag.SetString(version.c_str());
+  this->tune.SetString(tunename.c_str());
   this->datime.Now();
   this->runnu  = 0;
 }

--- a/src/Framework/Ntuple/NtpMCTreeHeader.h
+++ b/src/Framework/Ntuple/NtpMCTreeHeader.h
@@ -56,10 +56,11 @@ public :
 
   NtpMCFormat_t format;  ///< Event Record format (GENIE support multiple formats)
   TObjString    cvstag;  ///< GENIE CVS Tag (to keep track of GENIE's version)
+  TObjString    tune;    ///< GENIE Tune Name
   NtpMCDTime    datime;  ///< Date and Time that the event ntuple was generated
   Long_t        runnu;   ///< MC Job run number
 
-  ClassDef(NtpMCTreeHeader, 1)
+  ClassDef(NtpMCTreeHeader, 2)
 };
 
 }      // genie namespace

--- a/src/Framework/Ntuple/NtpMCTreeHeader.h
+++ b/src/Framework/Ntuple/NtpMCTreeHeader.h
@@ -56,9 +56,9 @@ public :
 
   NtpMCFormat_t format;  ///< Event Record format (GENIE support multiple formats)
   TObjString    cvstag;  ///< GENIE CVS Tag (to keep track of GENIE's version)
-  TObjString    tune;    ///< GENIE Tune Name
   NtpMCDTime    datime;  ///< Date and Time that the event ntuple was generated
   Long_t        runnu;   ///< MC Job run number
+  TObjString    tune;    ///< GENIE Tune Name
 
   ClassDef(NtpMCTreeHeader, 2)
 };

--- a/src/Framework/Ntuple/NtpMCTreeHeader.h
+++ b/src/Framework/Ntuple/NtpMCTreeHeader.h
@@ -54,13 +54,15 @@ public :
   // Ntuple is treated like a C-struct with public data members and
   // rule-breakinsg field data members not prefaced by "f" and mostly lowercase.
 
-  NtpMCFormat_t format;  ///< Event Record format (GENIE support multiple formats)
-  TObjString    cvstag;  ///< GENIE CVS Tag (to keep track of GENIE's version)
-  NtpMCDTime    datime;  ///< Date and Time that the event ntuple was generated
-  Long_t        runnu;   ///< MC Job run number
-  TObjString    tune;    ///< GENIE Tune Name
+  NtpMCFormat_t format;     ///< Event Record format (GENIE support multiple formats)
+  TObjString    cvstag;     ///< GENIE CVS Tag (to keep track of GENIE's version)
+  NtpMCDTime    datime;     ///< Date and Time that the event ntuple was generated
+  Long_t        runnu;      ///< MC Job run number
+  TObjString    tune;       ///< GENIE Tune Name
+  TObjString    tuneDir;    ///< directory from when tune config came
+  TObjString    customDirs; ///< any custom directories
 
-  ClassDef(NtpMCTreeHeader, 2)
+  ClassDef(NtpMCTreeHeader, 3)
 };
 
 }      // genie namespace

--- a/src/Framework/Ntuple/NtpWriter.cxx
+++ b/src/Framework/Ntuple/NtpWriter.cxx
@@ -105,16 +105,27 @@ void NtpWriter::Initialize()
 
   //-- create the tree header
   this->CreateTreeHeader();
-  //-- update the tune name from RunOpt (keep header from RunOpt entanglement)
+  //-- update the tune name (and associated directories) from RunOpt
+  //   (keep header from RunOpt entanglement)
   string tunename("unknown");
-  TuneId* tune = RunOpt::Instance()->Tune();
-  if ( ! tune ) {
+  string tuneDir("unknown");
+  string customDirs("");
+  TuneId* tuneId = RunOpt::Instance()->Tune();
+  if ( ! tuneId ) {
     LOG("Ntp", pERROR)
       << "No TuneId is available from RunOpt";
   } else {
-    tunename = tune->Name();
+    tunename = tuneId->Name();
+    tuneDir  = tuneId->TuneDirectory();
+    if ( tuneId->IsCustom() ) {
+      tunename += "*"; // flag it as possibly modified
+      customDirs = tuneId->CustomSource();
+    }
   }
   fNtpMCTreeHeader->tune.SetString(tunename.c_str());
+  fNtpMCTreeHeader->tuneDir.SetString(tuneDir.c_str());
+  fNtpMCTreeHeader->customDirs.SetString(customDirs.c_str());
+
   //-- write the tree header
   fNtpMCTreeHeader->Write();
 

--- a/src/Framework/Ntuple/NtpWriter.cxx
+++ b/src/Framework/Ntuple/NtpWriter.cxx
@@ -5,7 +5,7 @@
  or see $GENIE/LICENSE
 
  Author: Costas Andreopoulos <costas.andreopoulos \at stfc.ac.uk>
-         University of Liverpool & STFC Rutherford Appleton Lab 
+         University of Liverpool & STFC Rutherford Appleton Lab
 
  For the class documentation see the corresponding header file.
 
@@ -37,6 +37,7 @@
 #include "Framework/Ntuple/NtpMCTreeHeader.h"
 #include "Framework/Ntuple/NtpMCJobConfig.h"
 #include "Framework/Ntuple/NtpMCJobEnv.h"
+#include "Framework/Utils/RunOpt.h"
 
 #include "RVersion.h"
 
@@ -100,10 +101,21 @@ void NtpWriter::Initialize()
   this->CreateTree();           // create output tree
 
   //-- create the event branch
-  this->CreateEventBranch(); 
+  this->CreateEventBranch();
 
   //-- create the tree header
   this->CreateTreeHeader();
+  //-- update the tune name from RunOpt (keep header from RunOpt entanglement)
+  string tunename("unknown");
+  TuneId* tune = RunOpt::Instance()->Tune();
+  if ( ! tune ) {
+    LOG("Ntp", pERROR)
+      << "No TuneId is available from RunOpt";
+  } else {
+    tunename = tune->Name();
+  }
+  fNtpMCTreeHeader->tune.SetString(tunename.c_str());
+  //-- write the tree header
   fNtpMCTreeHeader->Write();
 
   //-- save GENIE configuration for this MC Job
@@ -128,7 +140,7 @@ void NtpWriter::CustomizeFilenamePrefix (string prefix)
 void NtpWriter::SetDefaultFilename(string filename_prefix)
 {
   ostringstream fnstr;
-  fnstr << filename_prefix  << "." 
+  fnstr << filename_prefix  << "."
         << fRunNu << "."
         << NtpMCFormat::FilenameTag(fNtpFormat)
         << ".root";
@@ -140,7 +152,7 @@ void NtpWriter::OpenFile(string filename)
 {
   if(fOutFile) delete fOutFile;
 
-  LOG("Ntp", pINFO) 
+  LOG("Ntp", pINFO)
       << "Opening the output ROOT file: " << filename;
 
   // use "TFile::Open()" instead of "new TFile()" so that it can handle
@@ -227,4 +239,3 @@ void NtpWriter::Save(void)
   }
 }
 //____________________________________________________________________________
-

--- a/src/Framework/Ntuple/NtpWriter.h
+++ b/src/Framework/Ntuple/NtpWriter.h
@@ -53,11 +53,11 @@ public :
   void Save (void);
 
   ///< get the even tree
-  TTree *  EventTree (void) { return fOutTree; }  
+  TTree *  EventTree (void) { return fOutTree; }
 
   ///< use before Initialize() only if you wish to override the default
   ///< filename, or the default filename prefix
-  void CustomizeFilename       (string filename);   
+  void CustomizeFilename       (string filename);
   void CustomizeFilenamePrefix (string prefix);
 
 private:
@@ -74,8 +74,8 @@ private:
   string             fOutFilename;        ///< output filename
   TFile *            fOutFile;            ///< output file
   TTree *            fOutTree;            ///< output tree
-  TBranch *          fEventBranch;        ///< the generated event branch 
-  NtpMCEventRecord * fNtpMCEventRecord;   ///< 
+  TBranch *          fEventBranch;        ///< the generated event branch
+  NtpMCEventRecord * fNtpMCEventRecord;   ///<
   NtpMCTreeHeader *  fNtpMCTreeHeader;    ///<
 };
 

--- a/src/Framework/Utils/TuneId.h
+++ b/src/Framework/Utils/TuneId.h
@@ -74,6 +74,8 @@ public:
   string Tail            (void) const ;
   string CMCDirectory    (void) const ;
   string TuneDirectory   (void) const ;
+  string BaseDirectory   (void) const { return fBaseDirectory; }
+  string CustomSource    (void) const { return fCustomSource;  }
 
   void   Build   (const string & name = "" ) ;
   void   Decode  (string id_str);


### PR DESCRIPTION
Append '*' to tune name if custom sources are involved.  There is a high probability of false positives on this (for instance if GXMLPATH is used to specify the location of spline files, or alternative Messager configs).  To that end, record the tuneDir and customDirs -- even though files might have been relocated at least it gives some hint of what was involved.