### PR TITLE
make interpreter loading neater

### DIFF
--- a/src/scripts/gcint/genie_setup.C
+++ b/src/scripts/gcint/genie_setup.C
@@ -10,15 +10,25 @@ void genie_setup()
 {
     TString script_dir = gSystem->Getenv("GENIE");
     script_dir += "/src/scripts/gcint/";
+    
+    int genie_incs_status = -999;
+    int genie_libs_status = -999;
 
-    TString curr_dir = gSystem->pwd();
-
-    gSystem->cd(script_dir.Data());
-
-    gROOT->ProcessLine(".x loadincs.C");
-    gROOT->ProcessLine(".x loadlibs.C");
-
-    gSystem->cd(curr_dir.Data());
+    TString loadincs = "#include \""+script_dir+"/loadincs.C\"";
+    TString execute_loadincs = TString::Format("*(int*)%p = loadincs();",&genie_incs_status);
+    
+    TString loadlibs = "#include \""+script_dir+"/loadlibs.C\"";
+    TString execute_loadlibs = TString::Format("*(int*)%p = loadlibs();",&genie_libs_status);
+    
+    gROOT->ProcessLine(loadincs.Data());
+    gROOT->ProcessLine(execute_loadincs.Data());
+    gROOT->ProcessLine(loadlibs.Data());
+    gROOT->ProcessLine(execute_loadlibs.Data());
+    
+    if (genie_incs_status || genie_libs_status) {
+      std::cerr<<"Failed to load GENIE libraries."<<std::endl;
+      exit(-1);
+    }
 
     change_prompt();
 }

--- a/src/scripts/gcint/loadincs.C
+++ b/src/scripts/gcint/loadincs.C
@@ -1,3 +1,4 @@
+int loadincs()
 {
   TString genie_topdir = gSystem->Getenv("GENIE");
 
@@ -32,5 +33,6 @@
 
   dip = ".include /usr/local/include/log4cpp";
   gROOT->ProcessLine(dip.Data());
-
+  
+  return 0;
 }


### PR DESCRIPTION
Slightly better detection of when something is wrong when the interpreter is loaded. No longer prints out a zero to screen every time interpreter is loaded