### PR TITLE
Fix memory leak in the gEvPick app

### DIFF
--- a/src/Apps/gEvPick.cxx
+++ b/src/Apps/gEvPick.cxx
@@ -254,8 +254,7 @@ void RunCherryPicker(void)
        if(AcceptEvent(event)) {
           brOrigFilename->SetString(chEl->GetTitle());
           brOrigEvtNum = iev;
-          EventRecord * event_copy = new EventRecord(event);
-          ntpw.AddEventRecord(iev_glob,event_copy);
+          ntpw.AddEventRecord( iev_glob, &event );
           iev_glob++;
        }
        mcrec->Clear();


### PR DESCRIPTION
In the existing code, a copy of the accepted event record is created but never deleted. This eventually fills memory in cases where many events are accepted. The gEvPick app works just as well without copying the event record, so I made that change.