### PR TITLE
update Makefile to pass both -dumpfullversion and -dumpversion to gcc

### DIFF
--- a/src/make/Make.include
+++ b/src/make/Make.include
@@ -258,7 +258,7 @@ USING_CLANG  = YES
 endif
 
 # get gcc version & split in '.' delimited tokens (major/minor/revison num.)
-CXXVRS      = $(shell $(CXX) -dumpversion)
+CXXVRS      = $(shell $(CXX) -dumpfullversion -dumpversion)
 CXXVRS_MAJ  = $(shell awk 'BEGIN {\
 		str="$(CXXVRS)"; split(str, tk, "."); print tk[1]}')
 CXXVRS_MIN  = $(shell awk 'BEGIN {\


### PR DESCRIPTION
Starting with gcc 7, gcc -dumpversion only outputs the major version causing
syntax errors like the following when building:

    awk: cmd. line:1: BEGIN { if(7>=4 && >0) print "YES"}
    awk: cmd. line:1:                    ^ syntax error

The new version of gcc now works like the old version when passing
-dumpfullversion. This commit updates src/make/Make.include to use both
-dumpfullversion and -dumpversion since that appears to work for both old and new
gcc versions.

I noticed this on my machine which is running Fedora 27 which uses gcc 7.3.1.

The idea to pass both options came from this stackoverflow post: https://stackoverflow.com/questions/45168516/gcc-7-1-1-on-fedora-26-dumpversion-now-only-includes-major-version-by-default.