### PR TITLE
Add "--tune" option to gevgen help message

### DIFF
--- a/src/Apps/gEvGen.cxx
+++ b/src/Apps/gEvGen.cxx
@@ -35,6 +35,7 @@
                   [--mc-job-status-refresh-rate  rate]
                   [--cache-file root_file]
                   [--xml-path config_xml_dir]
+                  [--tune G18_02a_00_000] (or your preferred tune identifier)
 
          Options :
            [] Denotes an optional argument.
@@ -117,7 +118,7 @@
 
 \cpright Copyright (c) 2003-2020, The GENIE Collaboration
          For the full text of the license visit http://copyright.genie-mc.org
-         
+
 */
 //____________________________________________________________________________
 
@@ -790,6 +791,7 @@ void PrintSyntax(void)
     << "\n              [--mc-job-status-refresh-rate  rate]"
     << "\n              [--cache-file root_file]"
     << "\n              [--xml-path config_xml_dir]"
+    << "\n              [--tune G18_02a_00_000] (or your preferred tune identifier)"
     << "\n";
 }
 //____________________________________________________________________________


### PR DESCRIPTION
Addresses a request from Jonathan Paley to explicitly document this option when running gevgen --help