### PR TITLE
Add the NCinclMEC event generator list

### DIFF
--- a/config/EventGeneratorListAssembler.xml
+++ b/config/EventGeneratorListAssembler.xml
@@ -476,6 +476,14 @@ Generator-%d                alg     No
      <param type="alg" name="Generator-2">   genie::EventGenerator/DME      </param>
   </param_set>
 
+  <param_set name="NCinclMEC">
+     <param type="int" name="NGenerators">   5                                  </param>
+     <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-NC       </param>
+     <param type="alg" name="Generator-1">   genie::EventGenerator/RES-NC       </param>
+     <param type="alg" name="Generator-2">   genie::EventGenerator/DIS-NC       </param>
+     <param type="alg" name="Generator-3">   genie::EventGenerator/COH-NC       </param>
+     <param type="alg" name="Generator-4">   genie::EventGenerator/MEC-NC       </param>
+  </param_set>
 
 </alg_conf>
 


### PR DESCRIPTION
GENIE v3.0.6 lacks a standard event generator list for NC inclusive that includes MEC. I've added a new one called NCinclMEC (based on CCinclMEC) to address this.