### PR TITLE
abort with an error if LoadFluxData() fails

### DIFF
--- a/src/Apps/gAtmoEvGen.cxx
+++ b/src/Apps/gAtmoEvGen.cxx
@@ -472,7 +472,7 @@ GFluxI* GetFlux(void)
      GHAKKMAtmoFlux * honda_flux = new GHAKKMAtmoFlux;
      atmo_flux_driver = dynamic_cast<GAtmoFlux *>(honda_flux);
   } else {
-     LOG("gevgen_atmo", pFATAL) << "Uknonwn flux simulation: " << gOptFluxSim;
+     LOG("gevgen_atmo", pFATAL) << "Unknown flux simulation: " << gOptFluxSim;
      gAbortingInErr = true;
      exit(1);
   }
@@ -487,7 +487,13 @@ GFluxI* GetFlux(void)
     string filename   = file_iter->second;
     atmo_flux_driver->AddFluxFile(neutrino_code, filename);
   }
-  atmo_flux_driver->LoadFluxData();
+
+  if (!atmo_flux_driver->LoadFluxData()) {
+    LOG("gevgen_atmo", pFATAL) << "Error loading flux data. Quitting...";
+    gAbortingInErr = true;
+    exit(1);
+  }
+
   // configure flux generation surface:
   atmo_flux_driver->SetRadii(gOptRL, gOptRT);
   // set rotation for coordinate tranformation from the topocentric horizontal

--- a/src/Tools/Flux/GAtmoFlux.cxx
+++ b/src/Tools/Flux/GAtmoFlux.cxx
@@ -439,16 +439,20 @@ bool GAtmoFlux::LoadFluxData(void)
     TH3D* hist = 0;
     std::map<int,TH3D*>::iterator myMapEntry = fRawFluxHistoMap.find(nu_pdg);
     if( myMapEntry == fRawFluxHistoMap.end() ){
-//      hist = myMapEntry->second;
-//      if(hist==0) {
         hist = this->CreateFluxHisto(pname.c_str(), pname.c_str());
         fRawFluxHistoMap.insert( map<int,TH3D*>::value_type(nu_pdg,hist) );
-//      }
     }
     // now let concrete instances to read the flux-specific data files
     // and fill the histogram
     bool loaded = this->FillFluxHisto(nu_pdg, filename);
+
     loading_status = loading_status && loaded;
+
+    if (!loaded) {
+        LOG("Flux", pERROR)
+          << "Error loading atmospheric neutrino flux simulation data from " << filename;
+        break;
+    }
   }
 
   if(loading_status) {


### PR DESCRIPTION
This commit updates gevgen_atmo to abort with an error if one of the flux files
fails to load when calling LoadFluxData(). I got bit by this where I
accidentally mistyped a single flux file and that flux failed to load, but
there was only a small warning but everything else continued to run.

I also updated LoadFluxData() to immediately abort if a single flux
file fails to load instead of continuing in order to make sure that the error
message about the file failing to load comes last.

I also fixed a small typo in gevgen_atmo.

I have tested this with a similar commit to version 2.12.8 but have only build tested the current pull request on master.