### PR TITLE
Ensure that the primary lepton polarization is set by all relevant generator classes

### DIFF
--- a/src/Physics/Coherent/EventGen/COHPrimaryLeptonGenerator.cxx
+++ b/src/Physics/Coherent/EventGen/COHPrimaryLeptonGenerator.cxx
@@ -78,5 +78,6 @@ void COHPrimaryLeptonGenerator::CalculatePrimaryLepton_AlvarezRuso(GHepRecord * 
   TLorentzVector p4l = kinematics.FSLeptonP4();
   int pdgc = interaction->FSPrimLepton()->PdgCode();
   this->AddToEventRecord(evrec, pdgc, p4l);
+  this->SetPolarization( evrec );
 }
 //___________________________________________________________________________

--- a/src/Physics/Common/PrimaryLeptonGenerator.cxx
+++ b/src/Physics/Common/PrimaryLeptonGenerator.cxx
@@ -14,6 +14,7 @@
 #include "Framework/Algorithm/AlgConfigPool.h"
 #include "Framework/Conventions/Constants.h"
 #include "Physics/Common/PrimaryLeptonGenerator.h"
+#include "Physics/Common/PrimaryLeptonUtils.h"
 #include "Framework/GHEP/GHepRecord.h"
 #include "Framework/GHEP/GHepParticle.h"
 #include "Framework/GHEP/GHepStatus.h"
@@ -210,41 +211,10 @@ void PrimaryLeptonGenerator::AddToEventRecord(
 //___________________________________________________________________________
 void PrimaryLeptonGenerator::SetPolarization(GHepRecord * ev) const
 {
-// Set the final state lepton polarization. A mass-less lepton would be fully
-// polarized. This would be exact for neutrinos and a very good approximation
-// for electrons for the energies this generator is going to be used. This is
-// not the case for muons and, mainly, for taus. I need to refine this later.
-// How? See Kuzmin, Lyubushkin and Naumov, hep-ph/0312107
-
-  // get the final state primary lepton
-  GHepParticle * fsl = ev->FinalStatePrimaryLepton();
-  if(!fsl) {
-     LOG("LeptonicVertex", pERROR)
-                    << "Final state lepton not set yet! \n" << *ev;
-     return;
-  }
-
-  // get (px,py,pz) @ LAB
-  TVector3 plab(fsl->Px(), fsl->Py(), fsl->Pz());
-
-  // in the limit m/E->0: leptons are left-handed and their anti-particles
-  // are right-handed
-  int pdgc = fsl->Pdg();
-  if(pdg::IsNeutrino(pdgc) || pdg::IsElectron(pdgc) ||
-                    pdg::IsMuon(pdgc) || pdg::IsTau(pdgc) ) {
-    plab *= -1; // left-handed
-  }
-
-  LOG("LeptonicVertex", pINFO)
-            << "Setting polarization angles for particle: " << fsl->Name();
-
-  fsl->SetPolarization(plab);
-
-  if(fsl->PolzIsSet()) {
-     LOG("LeptonicVertex", pINFO)
-          << "Polarization (rad): Polar = "  << fsl->PolzPolarAngle()
-                           << ", Azimuthal = " << fsl->PolzAzimuthAngle();
-  }
+  // The default treatment is just to delegate to the utility function.
+  // Derived classes that need a different approach may override this
+  // member function.
+  genie::utils::SetPrimaryLeptonPolarization( ev );
 }
 //___________________________________________________________________________
 void PrimaryLeptonGenerator::Configure(const Registry & config)

--- a/src/Physics/Common/PrimaryLeptonUtils.cxx
+++ b/src/Physics/Common/PrimaryLeptonUtils.cxx
@@ -1,0 +1,65 @@
+//____________________________________________________________________________
+/*
+ Copyright (c) 2003-2020, The GENIE Collaboration
+ For the full text of the license visit http://copyright.genie-mc.org
+
+ Steven Gardiner <gardiner \at fnal.gov>
+ Fermi National Accelerator Laboratory
+*/
+//____________________________________________________________________________
+
+#include "TVector3.h"
+
+#include "Physics/Common/PrimaryLeptonUtils.h"
+#include "Framework/GHEP/GHepRecord.h"
+#include "Framework/GHEP/GHepParticle.h"
+#include "Framework/Messenger/Messenger.h"
+#include "Framework/ParticleData/PDGUtils.h"
+
+using namespace genie;
+using namespace genie::utils;
+
+//___________________________________________________________________________
+void genie::utils::SetPrimaryLeptonPolarization( GHepRecord * ev )
+{
+// Moved out of the PrimaryLeptonGenerator class to make the same treatment
+// accessible for generators that use a more unified approach (e.g.,
+// QELEventGenerator and MECGenerator). -- S. Gardiner
+
+// Set the final state lepton polarization. A mass-less lepton would be fully
+// polarized. This would be exact for neutrinos and a very good approximation
+// for electrons for the energies this generator is going to be used. This is
+// not the case for muons and, mainly, for taus. I need to refine this later.
+// How? See Kuzmin, Lyubushkin and Naumov, hep-ph/0312107
+
+  // get the final state primary lepton
+  GHepParticle * fsl = ev->FinalStatePrimaryLepton();
+  if ( !fsl ) {
+    LOG("LeptonicVertex", pERROR)
+      << "Final state lepton not set yet! \n" << *ev;
+    return;
+  }
+
+  // Get (px,py,pz) @ LAB
+  TVector3 plab( fsl->Px(), fsl->Py(), fsl->Pz() );
+
+  // In the limit m/E->0: leptons are left-handed and their anti-particles
+  // are right-handed
+  int pdgc = fsl->Pdg();
+  if ( pdg::IsNeutrino(pdgc) || pdg::IsElectron(pdgc) ||
+    pdg::IsMuon(pdgc) || pdg::IsTau(pdgc) )
+  {
+    plab *= -1; // left-handed
+  }
+
+  LOG("LeptonicVertex", pINFO)
+    << "Setting polarization angles for particle: " << fsl->Name();
+
+  fsl->SetPolarization( plab );
+
+  if ( fsl->PolzIsSet() ) {
+    LOG("LeptonicVertex", pINFO)
+      << "Polarization (rad): Polar = "  << fsl->PolzPolarAngle()
+      << ", Azimuthal = " << fsl->PolzAzimuthAngle();
+  }
+}

--- a/src/Physics/Common/PrimaryLeptonUtils.h
+++ b/src/Physics/Common/PrimaryLeptonUtils.h
@@ -1,0 +1,34 @@
+//____________________________________________________________________________
+/*!
+
+\namespace  genie::utils
+
+\brief      Common functions used for handling generation of the primary
+            lepton, regardless of whether the relevant class inherits from
+            PrimaryLeptonGenerator or not.
+
+\author     Steven Gardiner <gardiner \at fnal.gov>
+            Fermi National Accelerator Laboratory
+
+\created    May 01, 2020
+
+\cpright    Copyright (c) 2003-2020, The GENIE Collaboration
+            For the full text of the license visit http://copyright.genie-mc.org
+*/
+//____________________________________________________________________________
+
+#ifndef _PRIMARY_LEPTON_UTILS_H
+#define _PRIMARY_LEPTON_UTILS_H
+
+namespace genie {
+
+class GHepRecord;
+
+namespace utils {
+
+  void SetPrimaryLeptonPolarization( GHepRecord* ev );
+
+} // utils   namespace
+} // genie   namespace
+
+#endif // _PRIMARY_LEPTON_UTILS_H

--- a/src/Physics/Multinucleon/EventGen/MECGenerator.cxx
+++ b/src/Physics/Multinucleon/EventGen/MECGenerator.cxx
@@ -25,6 +25,7 @@
 #include "Framework/GHEP/GHepParticle.h"
 #include "Framework/GHEP/GHepRecord.h"
 #include "Framework/Messenger/Messenger.h"
+#include "Physics/Common/PrimaryLeptonUtils.h"
 #include "Physics/Multinucleon/EventGen/MECGenerator.h"
 
 #include "Physics/NuclearState/NuclearModelI.h"
@@ -367,9 +368,13 @@ void MECGenerator::AddFinalStateLepton(GHepRecord * event) const
   // Lepton 4-position (= interacton vtx)
   TLorentzVector v4(*event->Probe()->X4());
 
+  // Add the final-state lepton to the event record
   int momidx = event->ProbePosition();
   event->AddParticle(
     pdgc, kIStStableFinalState, momidx, -1, -1, -1, p4l, v4);
+
+  // Set its polarization
+  utils::SetPrimaryLeptonPolarization( event );
 }
 //___________________________________________________________________________
 void MECGenerator::RecoilNucleonCluster(GHepRecord * event) const
@@ -851,6 +856,9 @@ void MECGenerator::SelectNSVLeptonKinematics (GHepRecord * event) const
 
   // -- Lepton
   event->AddParticle( pdgc, kIStStableFinalState, momidx, -1, -1, -1, p4l, v4);
+
+  // Set the final-state lepton polarization
+  utils::SetPrimaryLeptonPolarization( event );
 
   LOG("MEC",pDEBUG) << "~~~ LEPTON DONE ~~~";
 }

--- a/src/Physics/QuasiElastic/EventGen/QELEventGenerator.cxx
+++ b/src/Physics/QuasiElastic/EventGen/QELEventGenerator.cxx
@@ -34,6 +34,7 @@
 #include "Framework/ParticleData/PDGUtils.h"
 #include "Framework/ParticleData/PDGCodes.h"
 #include "Physics/QuasiElastic/EventGen/QELEventGenerator.h"
+#include "Physics/Common/PrimaryLeptonUtils.h"
 
 #include "Physics/NuclearState/NuclearModelI.h"
 #include "Framework/Numerical/MathUtils.h"
@@ -254,9 +255,14 @@ void QELEventGenerator::ProcessEventRecord(GHepRecord * evrec) const
             TLorentzVector outNucleon(interaction->KinePtr()->HadSystP4());
             TLorentzVector x4l(*(evrec->Probe())->X4());
 
+            // Add the final-state lepton to the event record
             evrec->AddParticle(interaction->FSPrimLeptonPdg(), kIStStableFinalState,
               evrec->ProbePosition(), -1, -1, -1, interaction->KinePtr()->FSLeptonP4(), x4l);
 
+            // Set its polarization
+            utils::SetPrimaryLeptonPolarization( evrec );
+
+            // Add the final-state nucleon to the event record
             GHepStatus_t ist = (tgt->IsNucleus()) ? kIStHadronInTheNucleus : kIStStableFinalState;
             evrec->AddParticle(interaction->RecoilNucleonPdg(), ist, evrec->HitNucleonPosition(),
               -1, -1, -1, interaction->KinePtr()->HadSystP4(), x4l);

--- a/src/Physics/QuasiElastic/EventGen/QELEventGeneratorSM.cxx
+++ b/src/Physics/QuasiElastic/EventGen/QELEventGeneratorSM.cxx
@@ -46,6 +46,7 @@
 
 
 #include "Framework/Utils/Range1.h"
+#include "Physics/Common/PrimaryLeptonUtils.h"
 #include "Physics/QuasiElastic/XSection/SmithMonizUtils.h"
 #include "Framework/Utils/KineUtils.h"
 #include "Framework/Utils/Cache.h"
@@ -304,7 +305,11 @@ void QELEventGeneratorSM::ProcessEventRecord(GHepRecord * evrec) const
   }
   TLorentzVector x4l(*(evrec->Probe())->X4());
 
+  // Add the final-state lepton to the event record
   evrec->AddParticle(interaction->FSPrimLeptonPdg(), kIStStableFinalState, evrec->ProbePosition(),-1,-1,-1, outLeptonMom, x4l);
+
+  // Set its polarization
+  utils::SetPrimaryLeptonPolarization( evrec );
 
   GHepStatus_t ist;
   if (!fGenerateNucleonInNucleus)


### PR DESCRIPTION
Move code to set the primary lepton polarization to a utility function. Set this polarization in the MECGenerator, QELEventGenerator, and QELEventGeneratorSM event record visitors.