### PR TITLE
Time fix

### DIFF
--- a/src/Framework/Conventions/Units.h
+++ b/src/Framework/Conventions/Units.h
@@ -24,14 +24,14 @@ namespace units {
 
 //-- Basic unit
 
-static const double gigaelectronvolt  = 1.;
-static const double GeV               = gigaelectronvolt;
+static constexpr double gigaelectronvolt  = 1.;
+static constexpr double GeV               = gigaelectronvolt;
 
 //-- Conversion of conventionl [L], [M], [T] units in physical units
 
-static const double meter    = 5.07e+15 / GeV;
-static const double kilogram = 5.61e+26 * GeV;
-static const double second   = 1.52e+24 / GeV;
+static constexpr double meter    = 5.07e+15 / GeV;
+static constexpr double kilogram = 5.61e+26 * GeV;
+static constexpr double second   = 1.52e+24 / GeV;
 
 // GeV^-2  -> mbarns : x 0.389;
 // mbarns  -> cm^2   : x 1.00E-27;
@@ -44,131 +44,140 @@ static const double second   = 1.52e+24 / GeV;
 
 //-- [L: length],[S: area],[V: volume]
 
-static const double kilometer   = 1000.*meter;
-static const double millimeter  = 0.001*meter;
-static const double millimeter2 = millimeter*millimeter;
-static const double millimeter3 = millimeter*millimeter2;
-static const double centimeter  = 0.01*meter;
-static const double centimeter2 = centimeter*centimeter;
-static const double centimeter3 = centimeter*centimeter2;
-static const double decimeter   = 0.1*meter;
-static const double decimeter2  = decimeter*decimeter;
-static const double decimeter3  = decimeter*decimeter2;
-static const double meter2      = meter*meter;
-static const double meter3      = meter*meter2;
-static const double micrometer  = 1.e-6 *meter;
-static const double nanometer   = 1.e-9 *meter;
-static const double angstrom    = 1.e-10*meter;
-static const double fermi       = 1.e-15*meter;
-static const double fermi2      = fermi*fermi;
-static const double fermi3      = fermi*fermi2;
-static const double barn        = 1.e-28*meter2;
-static const double millibarn   = 1.e-3 *barn;
-static const double microbarn   = 1.e-6 *barn;
-static const double nanobarn    = 1.e-9 *barn;
-static const double picobarn    = 1.e-12*barn;
+static constexpr double kilometer   = 1000.*meter;
+static constexpr double millimeter  = 0.001*meter;
+static constexpr double millimeter2 = millimeter*millimeter;
+static constexpr double millimeter3 = millimeter*millimeter2;
+static constexpr double centimeter  = 0.01*meter;
+static constexpr double centimeter2 = centimeter*centimeter;
+static constexpr double centimeter3 = centimeter*centimeter2;
+static constexpr double decimeter   = 0.1*meter;
+static constexpr double decimeter2  = decimeter*decimeter;
+static constexpr double decimeter3  = decimeter*decimeter2;
+static constexpr double meter2      = meter*meter;
+static constexpr double meter3      = meter*meter2;
+static constexpr double micrometer  = 1.e-6 *meter;
+static constexpr double nanometer   = 1.e-9 *meter;
+static constexpr double angstrom    = 1.e-10*meter;
+static constexpr double fermi       = 1.e-15*meter;
+static constexpr double fermi2      = fermi*fermi;
+static constexpr double fermi3      = fermi*fermi2;
+static constexpr double barn        = 1.e-28*meter2;
+static constexpr double millibarn   = 1.e-3 *barn;
+static constexpr double microbarn   = 1.e-6 *barn;
+static constexpr double nanobarn    = 1.e-9 *barn;
+static constexpr double picobarn    = 1.e-12*barn;
 
-static const double km  = kilometer;
-static const double mm  = millimeter;
-static const double mm2 = millimeter2;
-static const double mm3 = millimeter3;
-static const double cm  = centimeter;
-static const double cm2 = centimeter2;
-static const double cm3 = centimeter3;
-static const double m   = meter;
-static const double m2  = meter2;
-static const double m3  = meter3;
-static const double A   = angstrom;
-static const double fm  = fermi;
-static const double fm2 = fermi2;
-static const double fm3 = fermi3;
-static const double b   = barn;
-static const double mb  = millibarn;
-static const double ub  = microbarn;
-static const double nb  = nanobarn;
-static const double pb  = picobarn;
+static constexpr double km  = kilometer;
+static constexpr double mm  = millimeter;
+static constexpr double mm2 = millimeter2;
+static constexpr double mm3 = millimeter3;
+static constexpr double cm  = centimeter;
+static constexpr double cm2 = centimeter2;
+static constexpr double cm3 = centimeter3;
+static constexpr double m   = meter;
+static constexpr double m2  = meter2;
+static constexpr double m3  = meter3;
+static constexpr double A   = angstrom;
+static constexpr double fm  = fermi;
+static constexpr double fm2 = fermi2;
+static constexpr double fm3 = fermi3;
+static constexpr double b   = barn;
+static constexpr double mb  = millibarn;
+static constexpr double ub  = microbarn;
+static constexpr double nb  = nanobarn;
+static constexpr double pb  = picobarn;
 
 //-- [T: time]
 
-static const double millisecond = 1.e-03 *second;
-static const double microsecond = 1.e-06 *second;
-static const double nanosecond  = 1.e-09 *second;
-static const double picosecond  = 1.e-12 *second;
+static constexpr double millisecond = 1.e-03 *second;
+static constexpr double microsecond = 1.e-06 *second;
+static constexpr double nanosecond  = 1.e-09 *second;
+static constexpr double picosecond  = 1.e-12 *second;
+static constexpr double femptosecond  = 1.e-15 *second;
+static constexpr double attosecond  = 1.e-18 *second;
+static constexpr double zeptosecond  = 1.e-21 *second;
+static constexpr double yoctosecond  = 1.e-24 *second;
 
-static const double s  = second;
-static const double ms = millisecond;
-static const double us = microsecond;
-static const double ns = nanosecond;
-static const double ps = picosecond;
 
-static const double hertz     = 1./second;
-static const double kilohertz = 1.e+3*hertz;
-static const double megahertz = 1.e+6*hertz;
-static const double gigahertz = 1.e+9*hertz;
+static constexpr double s  = second;
+static constexpr double ms = millisecond;
+static constexpr double us = microsecond;
+static constexpr double ns = nanosecond;
+static constexpr double ps = picosecond;
+static constexpr double fs = femptosecond;
+static constexpr double as = attosecond;
+static constexpr double zs = zeptosecond;
+static constexpr double ys = yoctosecond; 
 
-static const double  Hz  = hertz;
-static const double  kHz = kilohertz;
-static const double  MHz = megahertz;
-static const double  GHz = gigahertz;
+static constexpr double hertz     = 1./second;
+static constexpr double kilohertz = 1.e+3*hertz;
+static constexpr double megahertz = 1.e+6*hertz;
+static constexpr double gigahertz = 1.e+9*hertz;
+
+static constexpr double  Hz  = hertz;
+static constexpr double  kHz = kilohertz;
+static constexpr double  MHz = megahertz;
+static constexpr double  GHz = gigahertz;
 
 //-- [Q: Charge]
 
-static const double qe          = 1.;
-static const double qe_coulomb  = 1.60217733e-19;
+static constexpr double qe          = 1.;
+static constexpr double qe_coulomb  = 1.60217733e-19;
 
 //-- [E: Energy]
 
-static const double     electronvolt = 1.e-09 *GeV;
-static const double kiloelectronvolt = 1.e+03 *electronvolt;
-static const double megaelectronvolt = 1.e+06 *electronvolt ;
-static const double teraelectronvolt = 1.e+12 *electronvolt;
-static const double petaelectronvolt = 1.e+15 *electronvolt;
+static constexpr double     electronvolt = 1.e-09 *GeV;
+static constexpr double kiloelectronvolt = 1.e+03 *electronvolt;
+static constexpr double megaelectronvolt = 1.e+06 *electronvolt ;
+static constexpr double teraelectronvolt = 1.e+12 *electronvolt;
+static constexpr double petaelectronvolt = 1.e+15 *electronvolt;
 
-static const double  eV = electronvolt;
-static const double keV = kiloelectronvolt;
-static const double MeV = megaelectronvolt;
-static const double TeV = teraelectronvolt;
-static const double PeV = petaelectronvolt;
+static constexpr double  eV = electronvolt;
+static constexpr double keV = kiloelectronvolt;
+static constexpr double MeV = megaelectronvolt;
+static constexpr double TeV = teraelectronvolt;
+static constexpr double PeV = petaelectronvolt;
 
-static const double GeV2 = GeV * GeV;
-static const double GeV3 = GeV * GeV2;
-static const double GeV4 = GeV * GeV3;
-static const double GeV5 = GeV * GeV4;
+static constexpr double GeV2 = GeV * GeV;
+static constexpr double GeV3 = GeV * GeV2;
+static constexpr double GeV4 = GeV * GeV3;
+static constexpr double GeV5 = GeV * GeV4;
 
 //-- [M: Mass]
 
-static const double      gram = 1.e-3 *kilogram;
-static const double milligram = 1.e-3 *gram;
+static constexpr double      gram = 1.e-3 *kilogram;
+static constexpr double milligram = 1.e-3 *gram;
 
-static const double  kg = kilogram;
-static const double   g = gram;
-static const double  mg = milligram;
+static constexpr double  kg = kilogram;
+static constexpr double   g = gram;
+static constexpr double  mg = milligram;
 
 //-- [Density]
 
-static const double  kilogram_meter3  = kilogram / meter3;
-static const double  gram_centimeter3 = gram     / centimeter3;
+static constexpr double  kilogram_meter3  = kilogram / meter3;
+static constexpr double  gram_centimeter3 = gram     / centimeter3;
 
-static const double kg_m3 = kilogram_meter3;
-static const double g_cm3 = gram_centimeter3;
+static constexpr double kg_m3 = kilogram_meter3;
+static constexpr double g_cm3 = gram_centimeter3;
 
 //-- [Dimensionless quantities]
 
 // Angle
 
-static const double radian      = 1.;
-static const double milliradian = 1.e-3*radian;
-static const double degree      = (3.14159265358979323846/180.0)*radian;
-static const double steradian   = 1.;
+static constexpr double radian      = 1.;
+static constexpr double milliradian = 1.e-3*radian;
+static constexpr double degree      = (3.14159265358979323846/180.0)*radian;
+static constexpr double steradian   = 1.;
 
-static const double rad  = radian;
-static const double mrad = milliradian;
-static const double sr   = steradian;
-static const double deg  = degree;
+static constexpr double rad  = radian;
+static constexpr double mrad = milliradian;
+static constexpr double sr   = steradian;
+static constexpr double deg  = degree;
 
 //-- [Etc]
 
-static const double clhep_def_density_unit = g_cm3/(0.62415185185E+19);
+static constexpr double clhep_def_density_unit = g_cm3/(0.62415185185E+19);
 
 } // namespace units
 } // namespace genie

--- a/src/Framework/GHEP/GHepParticle.h
+++ b/src/Framework/GHEP/GHepParticle.h
@@ -179,7 +179,7 @@ private:
   int              fFirstDaughter;  ///< first daughter idx
   int              fLastDaughter;   ///< last daughter idx
   TLorentzVector * fP4;             ///< momentum 4-vector (GeV)
-  TLorentzVector * fX4;             ///< position 4-vector (in the target nucleus coordinate system / x,y,z in fm / t=0)
+  TLorentzVector * fX4;             ///< position 4-vector (in the target nucleus coordinate system / x,y,z in fm / t from the moment of the primary interaction in ys(yocto second = 10^-24 s)
   double           fPolzTheta;      ///< polar polarization angle (rad)
   double           fPolzPhi;        ///< azimuthal polarization angle (rad)
   double           fRemovalEnergy;  ///< removal energy for bound nucleons (GeV)

--- a/src/Physics/Decay/PythiaDecayer.cxx
+++ b/src/Physics/Decay/PythiaDecayer.cxx
@@ -102,7 +102,6 @@ bool PythiaDecayer::Decay(int decay_particle_id, GHepRecord * event) const
 
   // Get the particle 4-momentum, 4-position and PDG code
   TLorentzVector decay_particle_p4 = *(decay_particle->P4());
-  TLorentzVector decay_particle_x4 = *(decay_particle->X4());
   int decay_particle_pdg_code = decay_particle->Pdg();
 
   // Convert to PYTHIA6 particle code and check whether decay is inhibited

--- a/src/Physics/Decay/PythiaDecayer.cxx
+++ b/src/Physics/Decay/PythiaDecayer.cxx
@@ -151,6 +151,14 @@ bool PythiaDecayer::Decay(int decay_particle_id, GHepRecord * event) const
   GHepParticle * target_nucleus = event->TargetNucleus();
   bool in_nucleus = (target_nucleus!=0);
 
+  // the values of space coordinates from pythia are in mm.
+  // our conventions want it in fm
+  constexpr double space_scale = units::mm / units::fm ; 
+
+  //  the values of time coordinate from pythia is in mm/c.
+  // our conventions want it in ys 
+  constexpr double time_scale = 1e21 * units::m / units::s ; 
+
   TMCParticle * p = 0;
   TIter particle_iter(impl);
   while( (p = (TMCParticle *) particle_iter.Next()) ) {
@@ -166,10 +174,10 @@ bool PythiaDecayer::Decay(int decay_particle_id, GHepRecord * event) const
         p->GetPy(),                // py
         p->GetPz(),                // pz
         p->GetEnergy(),            // e
-        p->GetVx(),                // x
-        p->GetVy(),                // y
-        p->GetVz(),                // z
-        p->GetTime()               // t
+        p->GetVx() * space_scale , // x
+        p->GetVy() * space_scale , // y
+        p->GetVz() * space_scale , // z
+        p->GetTime() * time_scale  // t
     );
 
     if(mcp.Status()==kIStNucleonTarget) continue; // mother particle, already in GHEP
@@ -188,10 +196,11 @@ bool PythiaDecayer::Decay(int decay_particle_id, GHepRecord * event) const
 
     TLorentzVector daughter_p4(
        mcp.Px(),mcp.Py(),mcp.Pz(),mcp.Energy());
+
     event->AddParticle(
        daughter_pdg_code, daughter_status_code,
        decay_particle_id,-1,-1,-1,
-       daughter_p4, decay_particle_x4);
+       daughter_p4, * mcp.X4() );
   }
 
   // Update the event weight for each weighted particle decay

--- a/src/contrib/pythia_units/pythia_units.C
+++ b/src/contrib/pythia_units/pythia_units.C
@@ -1,0 +1,85 @@
+#include "TString.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TH1.h"
+#include "TH2.h"
+
+#include "Framework/Ntuple/NtpMCTreeHeader.h"
+#include "Framework/Ntuple/NtpMCEventRecord.h"
+#include "Framework/EventGen/EventRecord.h"
+#include "Framework/ParticleData/BaryonResUtils.h"
+
+#include "Framework/GHEP/GHepParticle.h"
+#include "Framework/ParticleData/PDGUtils.h"
+#include "Framework/GHEP/GHepStatus.h"
+
+#include "Framework/ParticleData/PDGCodes.h"
+#include "Framework/ParticleData/PDGUtils.h"
+
+using namespace genie ;
+
+
+void pythia_units( TString in_file_name  = "gntp.0.ghep.root" ,
+		   TString out_file_name = "" ) {
+
+
+  if ( out_file_name == "" ) {
+    out_file_name = in_file_name ;
+    out_file_name.ReplaceAll( ".ghep.root",
+                              ".plots.root" ) ;
+  }
+
+  TFile in_file( in_file_name ) ;
+
+  NtpMCTreeHeader * header = dynamic_cast<NtpMCTreeHeader*> (in_file.Get("header"));
+
+  // Get the GENIE GHEP tree and set its branch address
+  TTree * in_tree = dynamic_cast<TTree*> (in_file.Get("gtree"));
+  NtpMCEventRecord * mcrec = 0;
+  in_tree->SetBranchAddress("gmcrec", & mcrec);
+
+  TFile out_file ( out_file_name, "RECREATE" ) ;
+  out_file.cd() ;
+
+  TTree out_tree( "tau_decay", "#tau decay" ) ;
+  
+  double length, time ;
+
+  out_tree.Branch( "L", & length, "L/D" );
+  out_tree.Branch( "T", & time, "T/D" );
+
+
+  // Event loop
+  for(Long64_t i=0; i < in_tree->GetEntries(); i++) {
+
+    in_tree->GetEntry(i);
+
+    EventRecord & event = *(mcrec->event);
+
+    const Interaction & inter = *( event.Summary() ) ;
+
+    int lep_pdg = inter.FSPrimLeptonPdg() ;
+
+    if ( TMath::Abs( lep_pdg ) == kPdgTau ) { 
+
+      const GHepParticle * tau = event.FinalStatePrimaryLepton() ;
+
+      const GHepParticle * first_daughter = event.Particle( tau -> FirstDaughter() ) ; 
+
+      TLorentzVector distance = * first_daughter -> X4() - * tau -> X4() ;
+
+      length = distance.Vect().Mag() ;
+      time = distance.T() ;
+
+      out_tree.Fill() ;
+
+    }
+    
+    mcrec->Clear() ;
+  } // event loop
+
+
+  out_tree.Write() ;
+
+
+}


### PR DESCRIPTION
This pull request assigns proper space and time coordinates from Pythia decayed particles according to our new definitions: space in fm and time in ys. 
I took the liberty to have some optimisations and I changed the unit definitions from `static const` to `static constepxr` so the scaling factors could be defined as `constexpr`. This trick could be done with constants as well but it was beyond the scope of this fixes and I will defer to a later moment. 

About the validation tests. I generated tau events, enabling the pythia decay for tau. The taus were generated on protons, with a uniform flux up to 35 GeV. 
With a macro (available in $GENIE/contrib/pythia_units) I extracted time of flight and decay length for the taus and I plotted them.
![points](https://user-images.githubusercontent.com/31312964/95986432-e3958700-0e1d-11eb-91dc-8bff103b0a8e.png)
As you can see the length goes up to 18 X 10^12. Being this in fm, this corresponds to a maximum of 1.8 cm which is expected from the typical OPERA experience. 

To understand the time unit, I fitted the points. 
![fit](https://user-images.githubusercontent.com/31312964/95986911-9cf45c80-0e1e-11eb-91cc-22db6e33ff5e.png)
![Screenshot from 2020-10-14 12-46-18](https://user-images.githubusercontent.com/31312964/95986924-9fef4d00-0e1e-11eb-8ea0-318c13e22e76.png)
The slope is about 0.3 fm / x and it is supposed to be the speed of the tau, which is heavily boosted so, close to the speed of light ( about 3 X 10^8 m/s ). Solving for x, that is 10 ^-24 s as expected. So the time is in ys. 

Let me know if we need more.

