### PR TITLE
Devel 02 11a config fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-bin/
+
+mySplines/bin/
 lib/
 doxygen/
 build-env.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-
-mySplines/bin/
+bin/
 lib/
 doxygen/
 build-env.log

--- a/config/G18_01a/G18_01a_02_11a/CommonParam.xml
+++ b/config/G18_01a/G18_01a_02_11a/CommonParam.xml
@@ -21,6 +21,17 @@ University of Liverpool
 
 <common_Param_list>
 
+  <param_set name="KNO2Pythia">
+    <!--
+    
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Invariant mass window for the transition from KNO model to PYTHIA
+    -->
+
+    <param type="double" name="KNO2PYTHIA-Wmin">  2.30 </param>
+    <param type="double" name="KNO2PYTHIA-Wmax">  3.00 </param>
+  </param_set>
+
 
  <param_set name="Tunable">
    <!-- Reserved register for tuning -->

--- a/config/G18_01a/G18_01a_02_11b/CommonParam.xml
+++ b/config/G18_01a/G18_01a_02_11b/CommonParam.xml
@@ -21,7 +21,6 @@ University of Liverpool
 
 <common_Param_list>
 
-
   <param_set name="Tunable">
     <!-- Reserved register for tuning -->
     <param type="double" name="RES-Ma"> 1.093718 </param>

--- a/config/G18_01b/G18_01b_02_11a/CommonParam.xml
+++ b/config/G18_01b/G18_01b_02_11a/CommonParam.xml
@@ -21,7 +21,6 @@ University of Liverpool
 
 <common_Param_list>
 
-
   <param_set name="Tunable">
     <!-- Reserved register for tuning -->
     <param type="double" name="RES-Ma">   0.989013 </param>

--- a/config/G18_02a/G18_02a_02_11a/CommonParam.xml
+++ b/config/G18_02a/G18_02a_02_11a/CommonParam.xml
@@ -21,6 +21,16 @@ University of Liverpool
 
 <common_Param_list>
 
+  <param_set name="KNO2Pythia">
+    <!--
+    
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Invariant mass window for the transition from KNO model to PYTHIA
+    -->
+
+    <param type="double" name="KNO2PYTHIA-Wmin">  2.30 </param>
+    <param type="double" name="KNO2PYTHIA-Wmax">  3.00 </param>
+  </param_set>
 
  <param_set name="Tunable">
    <!-- Reserved register for tuning -->

--- a/config/G18_02b/G18_02b_02_11a/CommonParam.xml
+++ b/config/G18_02b/G18_02b_02_11a/CommonParam.xml
@@ -21,6 +21,17 @@ University of Liverpool
 
 <common_Param_list>
 
+  <param_set name="KNO2Pythia">
+    <!--
+    
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Invariant mass window for the transition from KNO model to PYTHIA
+    -->
+
+    <param type="double" name="KNO2PYTHIA-Wmin">  2.30 </param>
+    <param type="double" name="KNO2PYTHIA-Wmax">  3.00 </param>
+  </param_set>
+
 
  <param_set name="Tunable">
    <!-- Reserved register for tuning -->

--- a/config/G18_10a/G18_10a_02_11a/CommonParam.xml
+++ b/config/G18_10a/G18_10a_02_11a/CommonParam.xml
@@ -22,6 +22,17 @@ University of Liverpool
 <common_Param_list>
 
 
+  <param_set name="KNO2Pythia">
+    <!--
+    
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Invariant mass window for the transition from KNO model to PYTHIA
+    -->
+
+    <param type="double" name="KNO2PYTHIA-Wmin">  2.30 </param>
+    <param type="double" name="KNO2PYTHIA-Wmax">  3.00 </param>
+  </param_set>
+
  <param_set name="Tunable">
    <!-- Reserved register for tuning -->
    <param type="double" name="RES-Ma">  1.065047  </param>


### PR DESCRIPTION
Resolving issue with GXY_AB_02_11a tunes. Coping the KNO2Pythia XML block into the tune-specific CommonParam.xml files while leaving everything else the same