### PR TITLE
added -fcommon flag to force common symbols

### DIFF
--- a/src/scripts/build/ext/build_pythia6.sh
+++ b/src/scripts/build/ext/build_pythia6.sh
@@ -519,8 +519,8 @@ tar xzvf ${toppath}/download/pythia6.tar.gz pythia6/pythia6_common_address.c
 mv pythia6/* .
 rmdir pythia6
 echo 'void MAIN__() {}' > main.c
-gcc -c -fPIC $m32flag main.c
-gcc -c -fPIC $m32flag pythia6_common_address.c
+gcc -c -fPIC -fcommon $m32flag main.c
+gcc -c -fPIC -fcommon $m32flag pythia6_common_address.c
 $FORT -c -fPIC -fno-second-underscore $m32flag tpythia6_called_from_cc.F
 
 cd ${toppath}/lib


### PR DESCRIPTION
With recent versions of gcc (at least on my system with gcc > 10.2) symbols are created in the BSS data section, whereas with old versions (tested with gcc 4.8) they are created as common. The linking of `pythia6_common_address` with `pydata` only works if symbols are created as common, otherwise the linker complains about multiple definitions.

Adding the flag `-fcommon` forces the symbols to be created as common even in modern compilers. Now it works on my system and with previous versions of gcc.