### PR TITLE
for COH interaction, the ConfigPool flag should be CC-PION/NC-PION, n…

### DIFF
--- a/config/GTEST19_10b/EventGenerator.xml
+++ b/config/GTEST19_10b/EventGenerator.xml
@@ -507,7 +507,7 @@ XSecModel                   alg     Yes  Cross section model used at the thread 
      <param type="alg"    name="Module-3">   genie::COHPrimaryLeptonGenerator/Default            </param>
      <param type="alg"    name="Module-4">   genie::COHHadronicSystemGenerator/Default           </param>
      <param type="alg"    name="Module-5">   genie::UnstableParticleDecayer/AfterHadronTransport </param>
-     <param type="alg"    name="ILstGen">    genie::COHInteractionListGenerator/NC-Default       </param>
+     <param type="alg"    name="ILstGen">    genie::COHInteractionListGenerator/NC-PION       </param>
   </param_set>
 
   <param_set name="COH-CC-PION">
@@ -519,7 +519,7 @@ XSecModel                   alg     Yes  Cross section model used at the thread 
      <param type="alg"    name="Module-3">   genie::COHPrimaryLeptonGenerator/Default            </param>
      <param type="alg"    name="Module-4">   genie::COHHadronicSystemGenerator/Default           </param>
      <param type="alg"    name="Module-5">   genie::UnstableParticleDecayer/AfterHadronTransport </param>
-     <param type="alg"    name="ILstGen">    genie::COHInteractionListGenerator/CC-Default       </param>
+     <param type="alg"    name="ILstGen">    genie::COHInteractionListGenerator/CC-PION       </param>
   </param_set>
 
   <!--


### PR DESCRIPTION
For COH interactions, the config flash should be CC-PION / NC-PION, not CC-Default/NC-Default
Such an issue was identified in the GTEST19_10b tune