### PR TITLE
Changing event generation list naming to include new physics processes

### DIFF
--- a/config/EventGeneratorListAssembler.xml
+++ b/config/EventGeneratorListAssembler.xml
@@ -257,25 +257,17 @@ Generator-%d                alg     No
   </param_set>
 
   <param_set name="NC"> 
-     <param type="int" name="NGenerators">   4                                  </param>
+     <param type="int" name="NGenerators">   6                                  </param>
      <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-NC       </param>
      <param type="alg" name="Generator-1">   genie::EventGenerator/RES-NC       </param>
      <param type="alg" name="Generator-2">   genie::EventGenerator/DIS-NC       </param>
-     <param type="alg" name="Generator-3">   genie::EventGenerator/COH-NC-PION       </param>
+     <param type="alg" name="Generator-3">   genie::EventGenerator/COH-NC-PION  </param>
+     <param type="alg" name="Generator-4">   genie::EventGenerator/MEC-NC       </param>
+     <param type="alg" name="Generator-5">   genie::EventGenerator/DFR-NC       </param>
   </param_set>
 
   <param_set name="CC"> 
-     <param type="int" name="NGenerators">   6                                  </param>
-     <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-CC       </param>
-     <param type="alg" name="Generator-1">   genie::EventGenerator/RES-CC       </param>
-     <param type="alg" name="Generator-2">   genie::EventGenerator/DIS-CC       </param>
-     <param type="alg" name="Generator-3">   genie::EventGenerator/COH-CC-PION       </param>
-     <param type="alg" name="Generator-4">   genie::EventGenerator/DIS-CC-CHARM </param>
-     <param type="alg" name="Generator-5">   genie::EventGenerator/QEL-CC-CHARM </param>
-  </param_set>
-
-  <param_set name="CCinclMEC"> 
-     <param type="int" name="NGenerators">   7                                  </param>
+     <param type="int" name="NGenerators">   8                                  </param>
      <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-CC       </param>
      <param type="alg" name="Generator-1">   genie::EventGenerator/RES-CC       </param>
      <param type="alg" name="Generator-2">   genie::EventGenerator/DIS-CC       </param>
@@ -283,6 +275,7 @@ Generator-%d                alg     No
      <param type="alg" name="Generator-4">   genie::EventGenerator/DIS-CC-CHARM </param>
      <param type="alg" name="Generator-5">   genie::EventGenerator/QEL-CC-CHARM </param>
      <param type="alg" name="Generator-6">   genie::EventGenerator/MEC-CC       </param>
+     <param type="alg" name="Generator-7">   genie::EventGenerator/DFR-CC       </param>
   </param_set>
 
   <param_set name="CCinclMECnoDIS"> 
@@ -304,64 +297,6 @@ Generator-%d                alg     No
      <param type="alg" name="Generator-5">   genie::EventGenerator/QEL-CC-CHARM </param>
      <param type="alg" name="Generator-6">   genie::EventGenerator/MEC-CC       </param>
      <param type="alg" name="Generator-7">   genie::EventGenerator/NUE-EL       </param>
-  </param_set>
-
-  <!-- Default+MEC is sometimes ambiguous about whether NC is included  -->
-  <!-- Define both Default+CCMEC and Default+CCMEC+NCMEC to be explicit -->
-  <!-- Possibly declare this one deprecated in the future               -->
-  <param_set name="Default+MEC"> 
-     <param type="int" name="NGenerators">   14                                 </param>
-     <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-CC       </param>
-     <param type="alg" name="Generator-1">   genie::EventGenerator/QEL-NC       </param>
-     <param type="alg" name="Generator-2">   genie::EventGenerator/RES-CC       </param>
-     <param type="alg" name="Generator-3">   genie::EventGenerator/RES-NC       </param>
-     <param type="alg" name="Generator-4">   genie::EventGenerator/DIS-CC       </param>
-     <param type="alg" name="Generator-5">   genie::EventGenerator/DIS-NC       </param>
-     <param type="alg" name="Generator-6">   genie::EventGenerator/COH-CC-PION       </param>
-     <param type="alg" name="Generator-7">   genie::EventGenerator/COH-NC-PION       </param>
-     <param type="alg" name="Generator-8">   genie::EventGenerator/DIS-CC-CHARM </param>
-     <param type="alg" name="Generator-9">   genie::EventGenerator/QEL-CC-CHARM </param>
-     <param type="alg" name="Generator-10">  genie::EventGenerator/NUE-EL       </param>
-     <param type="alg" name="Generator-11">  genie::EventGenerator/IMD          </param>
-     <param type="alg" name="Generator-12">  genie::EventGenerator/IMD-ANH      </param>
-     <param type="alg" name="Generator-13">  genie::EventGenerator/MEC-CC       </param>
-  </param_set>
-
-  <param_set name="Default+CCMEC"> 
-     <param type="int" name="NGenerators">   14                                 </param>
-     <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-CC       </param>
-     <param type="alg" name="Generator-1">   genie::EventGenerator/QEL-NC       </param>
-     <param type="alg" name="Generator-2">   genie::EventGenerator/RES-CC       </param>
-     <param type="alg" name="Generator-3">   genie::EventGenerator/RES-NC       </param>
-     <param type="alg" name="Generator-4">   genie::EventGenerator/DIS-CC       </param>
-     <param type="alg" name="Generator-5">   genie::EventGenerator/DIS-NC       </param>
-     <param type="alg" name="Generator-6">   genie::EventGenerator/COH-CC-PION       </param>
-     <param type="alg" name="Generator-7">   genie::EventGenerator/COH-NC-PION       </param>
-     <param type="alg" name="Generator-8">   genie::EventGenerator/DIS-CC-CHARM </param>
-     <param type="alg" name="Generator-9">   genie::EventGenerator/QEL-CC-CHARM </param>
-     <param type="alg" name="Generator-10">  genie::EventGenerator/NUE-EL       </param>
-     <param type="alg" name="Generator-11">  genie::EventGenerator/IMD          </param>
-     <param type="alg" name="Generator-12">  genie::EventGenerator/IMD-ANH      </param>
-     <param type="alg" name="Generator-13">  genie::EventGenerator/MEC-CC       </param>
-  </param_set>
-
-  <param_set name="Default+CCMEC+NCMEC"> 
-     <param type="int" name="NGenerators">   15                                 </param>
-     <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-CC       </param>
-     <param type="alg" name="Generator-1">   genie::EventGenerator/QEL-NC       </param>
-     <param type="alg" name="Generator-2">   genie::EventGenerator/RES-CC       </param>
-     <param type="alg" name="Generator-3">   genie::EventGenerator/RES-NC       </param>
-     <param type="alg" name="Generator-4">   genie::EventGenerator/DIS-CC       </param>
-     <param type="alg" name="Generator-5">   genie::EventGenerator/DIS-NC       </param>
-     <param type="alg" name="Generator-6">   genie::EventGenerator/COH-CC-PION       </param>
-     <param type="alg" name="Generator-7">   genie::EventGenerator/COH-NC-PION       </param>
-     <param type="alg" name="Generator-8">   genie::EventGenerator/DIS-CC-CHARM </param>
-     <param type="alg" name="Generator-9">   genie::EventGenerator/QEL-CC-CHARM </param>
-     <param type="alg" name="Generator-10">  genie::EventGenerator/NUE-EL       </param>
-     <param type="alg" name="Generator-11">  genie::EventGenerator/IMD          </param>
-     <param type="alg" name="Generator-12">  genie::EventGenerator/IMD-ANH      </param>
-     <param type="alg" name="Generator-13">  genie::EventGenerator/MEC-CC       </param>
-     <param type="alg" name="Generator-14">  genie::EventGenerator/MEC-NC       </param>
   </param_set>
 
   <!-- 
@@ -388,14 +323,10 @@ Generator-%d                alg     No
      <param type="alg" name="Generator-0">   genie::EventGenerator/DIS-EM       </param>
   </param_set>
 
-  <param_set name="EM"> 
-     <param type="int" name="NGenerators">   3                                  </param>
-     <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-EM       </param>
-     <param type="alg" name="Generator-1">   genie::EventGenerator/RES-EM       </param>
-     <param type="alg" name="Generator-2">   genie::EventGenerator/DIS-EM       </param>
-  </param_set>
+  <!-- For future versions-->
+  <!-- We also need EM COH, DFR and e-e scattering processes-->
 
-  <param_set name="EM+MEC"> 
+  <param_set name="EM"> 
      <param type="int" name="NGenerators">   4                                  </param>
      <param type="alg" name="Generator-0">   genie::EventGenerator/QEL-EM       </param>
      <param type="alg" name="Generator-1">   genie::EventGenerator/RES-EM       </param>


### PR DESCRIPTION
Changing event generation list naming to include new physics processes by default (like MEC & DFR)
Simplifying the naming scheme, that is "CC", "NC" and "EM" instead of "CCinclMEC" and "EM+MEC" [there was no inclusive process list for NC]