### PR TITLE
resolve a number of small issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,14 @@ endif
 make-install-dirs: FORCE
 	@echo " "
 	@echo "** Creating directory structure for GENIE installation..."
+ifeq (${GENIE_INSTALLATION_PATH},/usr)
+	cd ${GENIE}
+	$(warning Installation in /usr or /usr/local is discouraged)
+endif
+ifeq (${GENIE_INSTALLATION_PATH},/usr/local)
+	cd ${GENIE}
+	$(warning Installation in /usr or /usr/local is discouraged)
+endif
 	[ -d ${GENIE_INSTALLATION_PATH} ] || mkdir ${GENIE_INSTALLATION_PATH}
 	cd ${GENIE_INSTALLATION_PATH}
 	[ -d ${GENIE_BIN_INSTALLATION_PATH}     ] || mkdir ${GENIE_BIN_INSTALLATION_PATH}
@@ -631,6 +639,18 @@ clean-etc: FORCE
 distclean: FORCE
 	@echo " "
 	@echo "** Cleaning GENIE installation... "
+ifeq (${GENIE_INSTALLATION_PATH},/usr)
+	cd ${GENIE}
+	$(warning Installation in /usr or /usr/local is discouraged)
+	$(warning   as "distclean" is too aggressive and removes more than just GENIE libraries)
+	$(error Installation directory ${GENIE_INSTALLATION_PATH} is too precious.  Must be removed by hand)
+endif
+ifeq (${GENIE_INSTALLATION_PATH},/usr/local)
+	cd ${GENIE}
+	$(warning Installation in /usr or /usr/local is discouraged)
+	$(warning   as "distclean" is too aggressive and removes more than just GENIE libraries)
+	$(error Installation directory ${GENIE_INSTALLATION_PATH} is too precious.  Must be removed by hand)
+endif
 	[ ! -d ${GENIE_INSTALLATION_PATH}/include/GENIE ] || rm -rf ${GENIE_INSTALLATION_PATH}/include/GENIE/
 	cd ${GENIE}/src/Framework/Algorithm                      &&  $(MAKE) distclean && \
 	cd ${GENIE}/src/Framework/Conventions                    &&  $(MAKE) distclean && \
@@ -692,5 +712,6 @@ distclean: FORCE
 	cd ${GENIE}/src/Apps                                     &&  $(MAKE) distclean && \
 	cd ${GENIE}/src/scripts                                  &&  $(MAKE) distclean && \
 	cd ${GENIE}
+
 
 FORCE:

--- a/configure
+++ b/configure
@@ -786,10 +786,10 @@ if($gopt_enable_incl eq "YES") {
   }
 
   # check
-  my $fileso = "$gopt_with_boost_lib/libboost_program_options-mt.so";
-  my $filea  = "$gopt_with_boost_lib/libboost_program_options-mt.a";
+  my $fileso = "$gopt_with_boost_lib/libboost_program_options.so";
+  my $filea  = "$gopt_with_boost_lib/libboost_program_options.a";
   if(! -e $fileso && ! -e $filea) {
-    print "*** Error *** You need to specify the path to libboost_program_options-mt.so using --with-boost-lib=/some/path/\n";
+    print "*** Error *** You need to specify the path to libboost_program_options.so using --with-boost-lib=/some/path/\n";
     print "*** Error *** Otherwise, you should --disable-incl\n\n";
     exit 1;
   }

--- a/src/make/Make.include
+++ b/src/make/Make.include
@@ -352,6 +352,10 @@ endif
 GCC_GE_4_1_0  = $(shell awk 'BEGIN {\
 		if($(CXXVRS_MAJ)>=4 && $(CXXVRS_MIN)>0) print "YES"}')
 
+# gcc version >= 8.0.0 ?
+GCC_GE_8_0_0  = $(shell awk 'BEGIN {\
+		if($(CXXVRS_MAJ)>=8 && $(CXXVRS_MIN)>0) print "YES"}')
+
 
 # MAC OS X with gcc or clang, 32-bit mode
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -384,34 +388,6 @@ OutPutOpt     = -o
 SOMINF        =
 EXTRALIBS     =
 endif
-
-#ifeq ($(strip $(ARCH)),macosx)
-#ARCH_OK       = YES
-#IS_MACOSX     = YES
-#CXXFLAGS      = -pipe -W -Wall -Wno-long-double \
-#		-fsigned-char -fno-common -flat_namespace \#
-#		$(GOPT_WITH_CXX_DEBUG_FLAG) \
-#		$(GOPT_WITH_CXX_OPTIMIZ_FLAG) \
-#		$(GOPT_WITH_CXX_USERDEF_FLAGS)
-#ifeq ($(strip $(GCC_GE_4_1_0)), YES)
-#  CXXFLAGS += -Wno-strict-aliasing -ffriend-injection
-#endif
-#LDFLAGS       = -bind_at_load
-#SOFLAGS       = -dynamiclib -flat_namespace \
-#		-single_module -undefined dynamic_lookup
-#DllSuf       := dylib
-#DllLinkSuf   := so
-#StaticLibSuf := a
-#ObjSuf       := o
-#SrcSuf       := cxx
-#FORT         := g77
-#FORTOPTS     := $(FFLAGS) -g -c -O -DLINUX $(F77INCS) -fno-second-underscore
-#RANLIB       := ranlib
-#SOCMD         = $(LD)
-#OutPutOpt     = -o
-#SOMINF        =
-#EXTRALIBS     =
-#endif
 
 # MAC OS X with gcc or clang, 64-bit mode
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -472,33 +448,6 @@ SOMINF        =
 EXTRALIBS     =
 endif
 
-#ifeq ($(strip $(ARCH)),macosx64)
-#ARCH_OK       = YES
-#IS_MACOSX     = YES
-#CXXFLAGS      = -m64 -pipe -W -Wall \
-#		-fsigned-char -fno-common -flat_namespace \
-#		$(GOPT_WITH_CXX_DEBUG_FLAG) \
-#		$(GOPT_WITH_CXX_OPTIMIZ_FLAG) \
-#		$(GOPT_WITH_CXX_USERDEF_FLAGS)
-#ifeq ($(strip $(GCC_GE_4_1_0)), YES)
-#  CXXFLAGS += -Wno-strict-aliasing -ffriend-injection
-#endif
-#LDFLAGS       = -bind_at_load
-#SOFLAGS       = -dynamiclib -flat_namespace \
-#		-single_module -undefined dynamic_lookup
-#DllSuf       := dylib
-#DllLinkSuf   := so
-#StaticLibSuf := a
-#ObjSuf       := o
-#SrcSuf       := cxx
-#FORT         := g77
-#FORTOPTS     := $(FFLAGS) -g -c -O -DLINUX $(F77INCS) -fno-second-underscore
-#RANLIB       := ranlib
-#SOCMD         = $(LD)
-#OutPutOpt     = -o
-#SOMINF        =
-#EXTRALIBS     =
-#endif
 
 # LINUX / 32-bit x86 / with gcc
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -509,8 +458,13 @@ CXXFLAGS      = -W -Wall -fPIC -Wshadow \
 		$(GOPT_WITH_CXX_DEBUG_FLAG) \
 		$(GOPT_WITH_CXX_OPTIMIZ_FLAG) \
 		$(GOPT_WITH_CXX_USERDEF_FLAGS)
-ifeq ($(strip $(GCC_GE_4_1_0)), YES) 
-  CXXFLAGS += -Wno-strict-aliasing -ffriend-injection
+ifeq ($(strip $(GCC_GE_8_0_0)), YES)
+  # -ffriend-injection is deprecated, soon to go away
+  CXXFLAGS += -Wno-strict-aliasing
+else
+  ifeq ($(strip $(GCC_GE_4_1_0)), YES)
+    CXXFLAGS += -Wno-strict-aliasing -ffriend-injection
+  endif
 endif
 LDFLAGS       = -g -Wl,--no-as-needed -Wl,--no-undefined
 SOFLAGS       = -shared
@@ -537,8 +491,13 @@ CXXFLAGS      = -W -Wall -fPIC -Wshadow \
 		$(GOPT_WITH_CXX_DEBUG_FLAG) \
 		$(GOPT_WITH_CXX_OPTIMIZ_FLAG) \
 		$(GOPT_WITH_CXX_USERDEF_FLAGS)
-ifeq ($(strip $(GCC_GE_4_1_0)), YES) 
-  CXXFLAGS += -Wno-strict-aliasing -ffriend-injection
+ifeq ($(strip $(GCC_GE_8_0_0)), YES)
+  # -ffriend-injection is deprecated, soon to go away
+  CXXFLAGS += -Wno-strict-aliasing
+else
+  ifeq ($(strip $(GCC_GE_4_1_0)), YES)
+    CXXFLAGS += -Wno-strict-aliasing -ffriend-injection
+  endif
 endif
 LDFLAGS       = -g -Wl,--no-as-needed -Wl,--no-undefined
 SOFLAGS       = -shared

--- a/src/make/Make.std-package-targets
+++ b/src/make/Make.std-package-targets
@@ -51,10 +51,7 @@ $(DICTIONARY).cc: LinkDef.h $(DICTGEN_OBJECTS)
 	$(RM) $(DICTIONARY).*
 	@echo "[package: $(PACKAGE)] Generating ROOT dictionary ..."
 #	rootcint -f $(DICTIONARY).cc -c $(ROOT_DICT_GEN_INCLUDES) $(DICTGEN_HEADERS) LinkDef.h
-ifeq ($(ROOT_MAJOR),5)
-        # add -p flag to use cpp rather than CINT
-	  rootcint -f $(DICTIONARY).cc -c -p $(ROOT_DICT_GEN_INCLUDES) $(DICTGEN_HEADERS) LinkDef.h
-else
+ifeq ($(ROOT_MAJOR),6)
         # to make pcm relocatable we have to set it to strip these off
         # sub-dirs Types & Interfaces don't have dictionaries, made as part of Nuclear
         # so we have to explicitly (in case of Nuclear, no harm doing for rest)
@@ -104,7 +101,6 @@ ifeq ($(strip $(IS_MACOSX)),YES)
 	$(SYMLINK) $(PACKAGE_LIB) $(PACKAGE_LIBMACLINK_WITH_PATH)
 endif
 
-
 $(PACKAGE_LIBNOVRS_WITH_PATH): $(PACKAGE_LIB_WITH_PATH)
 	@echo "[package: $(PACKAGE)] Creating symbolic link to shared library ..."
 ifeq ($(strip $(GOPT_ENABLE_DYLIBVERSION)),YES)
@@ -114,7 +110,6 @@ endif
 #
 #
 lib-link: $(PACKAGE_LIBNOVRS_WITH_PATH) $(PACKAGE_LIBMACLINK_WITH_PATH)
-
 
 #
 #
@@ -129,10 +124,12 @@ install-lib:
 ifeq ($(strip $(GOPT_ENABLE_DYLIBVERSION)),YES)
 	[ ! -f $(PACKAGE_LIB_WITH_PATH) ] || $(SYMLINK) $(PACKAGE_LIB) $(PACKAGE_LIBNOVRS_WITH_IPATH)
 endif
+
 ifeq ($(ROOT_MAJOR),6)
 	[ ! -f $(PACKAGE_PCM_WITH_PATH) ]     || $(COPY) $(PACKAGE_PCM_WITH_PATH) $(GENIE_LIB_INSTALLATION_PATH)
 	[ ! -f $(PACKAGE_ROOTMAP_WITH_PATH) ] || $(COPY) $(PACKAGE_ROOTMAP_WITH_PATH) $(GENIE_LIB_INSTALLATION_PATH)
 endif
+
 ifeq ($(strip $(ARCH)),macosx)
 	[ ! -f $(PACKAGE_LIB_WITH_PATH) ] || $(SYMLINK) $(PACKAGE_LIB) $(PACKAGE_LIBMACLINK_WITH_IPATH)
 endif


### PR DESCRIPTION
This pull request should resolve issues
#149 loadlibs.C failing when "-l" installation path;  match "-l" at beginning of token
#116 don't perform "distclean" on /usr or /usr/local
#145 remove leftover ROOT5 cruft
it also remove -ffriend-injection flag (deprecated) when using gcc >= 8.0.0
and loadlibs.C also handles -L/path/dir from genie-config --libs (and a small potential memory leak)
for INCL++ look for non-mt boost library 