### PR TITLE
Addition of start time of ray (in parallel to start position) and passing it on when used as flux driver

### DIFF
--- a/src/Tools/Flux/GSimpleNtpFlux.cxx
+++ b/src/Tools/Flux/GSimpleNtpFlux.cxx
@@ -276,7 +276,8 @@ bool GSimpleNtpFlux::GenerateNext_weighted(void)
   // Update the curr neutrino p4/x4 lorentz vector
   double Ev =  fCurEntry->E;
   fP4.SetPxPyPzE(fCurEntry->px,fCurEntry->py,fCurEntry->pz,Ev);
-  fX4.SetXYZT(fCurEntry->vtxx,fCurEntry->vtxy,fCurEntry->vtxz,0);
+  double t0 = ((fIncludeVtxt) ? fCurEntry->vtxt : 0 );
+  fX4.SetXYZT(fCurEntry->vtxx,fCurEntry->vtxy,fCurEntry->vtxz,t0);
 
   fWeight = fCurEntry->wgt;
 
@@ -737,6 +738,8 @@ void GSimpleNtpFlux::Initialize(void)
   fAllFilesMeta    = true;
   fAlreadyUnwgt    = false;
 
+  fIncludeVtxt     = false;
+
   this->SetDefaults();
   this->ResetCurrent();
 }
@@ -835,6 +838,7 @@ void GSimpleNtpEntry::Reset()
   vtxx     = 0.;
   vtxy     = 0.;
   vtxz     = 0.;
+  vtxt     = 0.;
   dist     = 0.;
   px       = 0.;
   py       = 0.;
@@ -968,7 +972,7 @@ namespace flux  {
              << " wgt " << entry.wgt
              << " ( metakey " << entry.metakey << " )"
              << "\n   vtx [" << entry.vtxx << "," << entry.vtxy << ","
-             << entry.vtxz << "] dist " << entry.dist
+             << entry.vtxz << ", t=" << entry.vtxt << "] dist " << entry.dist
              << "\n   p4  [" << entry.px << "," << entry.py << ","
              << entry.pz << "," << entry.E << "]";
      return stream;

--- a/src/Tools/Flux/GSimpleNtpFlux.h
+++ b/src/Tools/Flux/GSimpleNtpFlux.h
@@ -11,7 +11,7 @@
 \created  Jan 25, 2010
 
 \cpright  Copyright (c) 2003-2020, The GENIE Collaboration
-          For the full text of the license visit http://copyright.genie-mc.org          
+          For the full text of the license visit http://copyright.genie-mc.org
 */
 //____________________________________________________________________________
 
@@ -68,12 +68,13 @@ ostream & operator << (ostream & stream, const GSimpleNtpEntry & info);
 
     Double_t   wgt;      ///< nu weight
 
-    Double_t   vtxx;     ///< x position in lab frame
+    Double_t   vtxx;     ///< x position in lab frame (meters)
     Double_t   vtxy;     ///< y position in lab frame
     Double_t   vtxz;     ///< z position in lab frame
+    Double_t   vtxt;     ///< time of ray start (seconds)
     Double_t   dist;     ///< distance from hadron decay
 
-    Double_t   px;       ///< x momentum in lab frame
+    Double_t   px;       ///< x momentum in lab frame (GeV)
     Double_t   py;       ///< y momentum in lab frame
     Double_t   pz;       ///< z momentum in lab frame
     Double_t   E;        ///< energy in lab frame
@@ -81,7 +82,7 @@ ostream & operator << (ostream & stream, const GSimpleNtpEntry & info);
     Int_t      pdg;      ///< nu pdg-code
     UInt_t     metakey;  ///< key to meta data
 
-    ClassDef(GSimpleNtpEntry,1)
+    ClassDef(GSimpleNtpEntry,2)
   };
 
 
@@ -245,6 +246,9 @@ public :
   double    GetDecayDist() const; ///< dist (user units) from dk to current pos
   void      MoveToZ0(double z0);  ///< move ray origin to user coord Z0
 
+  void      SetIncludeVtxt(bool it=true); ///< should X4 include CurEntry.vtxt
+  bool      GetIncludeVtxt() { return fIncludeVtxt; }
+
   //
   // information about the current state
   //
@@ -324,7 +328,6 @@ private:
 
   long int  fNUse;                ///< how often to use same entry in a row
   long int  fIUse;                ///< current # of times an entry has been used
-
   double    fSumWeight;           ///< sum of weights for nus thrown so far
   long int  fNNeutrinos;          ///< number of flux neutrinos thrown so far
   long int  fNEntriesUsed;        ///< number of entries read from files
@@ -346,6 +349,8 @@ private:
   GSimpleNtpEntry* fCurEntryCopy;  ///< current entry
   GSimpleNtpNuMI*  fCurNuMICopy;   ///< current "numi" branch extra info
   GSimpleNtpAux*   fCurAuxCopy;    ///< current "aux" branch extra info
+
+  bool             fIncludeVtxt;   ///< does fX4 include CurEntry.vtxt or 0
 
 };
 


### PR DESCRIPTION
Addition of time variable for start of flux ray (to be filled by, say, dk2nu) representing time from proton-on-target to the flux window that is the start of the ray.

Pass this time along as part of X4 in flux driver mode with option, for backward compatibility, of ignoring it.