### PR TITLE
Scale MEC as function of W

### DIFF
--- a/config/ScaleMECW.xml
+++ b/config/ScaleMECW.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<alg_conf>
+<!--
+Configuration for the ScaleMECW
+Configurable Parameters:
+......................................................................................................................
+Name                       Type     Optional   Comment                                       Default
+......................................................................................................................
+ScaleMECW-Weight-Default   double   Yes        Default Qvalue Shift for all targets          1.
+ScaleMECW-Weight-QELRegion double   Yes        Weight factor applied at W=Mn                 
+ScaleMECW-Weight-RESRegion double   Yes        Weight factor applied at W=MDelta
+-->
+
+  <param_set name="Default"> 
+    <param type="double"  name="ScaleMECW-Weight-Default"> 1. </param>   
+    <param type="double"  name="ScaleMECW-Weight-QELRegion"> 1. </param>   
+    <param type="double"  name="ScaleMECW-Weight-RESRegion"> 1. </param>   
+  </param_set>
+
+</alg_conf>

--- a/src/Physics/Multinucleon/XSection/LinkDef.h
+++ b/src/Physics/Multinucleon/XSection/LinkDef.h
@@ -13,4 +13,6 @@
 
 #pragma link C++ class genie::MECXSec;
 
+#pragma link C++ class genie::ScaleMECW;
+
 #endif

--- a/src/Physics/Multinucleon/XSection/NievesSimoVacasMECPXSec2016.h
+++ b/src/Physics/Multinucleon/XSection/NievesSimoVacasMECPXSec2016.h
@@ -31,6 +31,7 @@
 
 #include "Framework/EventGen/XSecAlgorithmI.h"
 #include "Physics/HadronTensors/HadronTensorModelI.h"
+#include "Physics/Multinucleon/XSection/ScaleMECW.h"
 
 namespace genie {
 
@@ -63,6 +64,8 @@ private:
   const HadronTensorModelI* fHadronTensorModel;
 
   const XSecIntegratorI *  fXSecIntegrator; // Numerical integrator (GSL)
+
+  const ScaleMECW * fScaleMECW ; // Optional algorithm to retrieve the MEC scale as a function of W
 
 };
 

--- a/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
+++ b/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
@@ -47,7 +47,7 @@ void ScaleMECW::Configure(string config)
     this->LoadConfig();
 }
 //_________________________________________________________________________
-double ScaleMECW::GetScaling( double q0, double q3 ) const
+double ScaleMECW::GetScaling( const double q0, const double q3 ) const
 {
   // The Scaling is done using the "experimenter's W", which assumes a single nucleon
   // See motivation in : https://arxiv.org/pdf/1601.02038.pdf

--- a/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
+++ b/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
@@ -1,0 +1,115 @@
+//_________________________________________________________________________
+/*
+ Copyright (c) 2003-2020, The GENIE Collaboration
+ For the full text of the license visit http://copyright.genie-mc.org
+
+ Original code contributed by J.Tena and M.Roda
+ Substantial code refactorizations by the core GENIE group.
+*/
+//_________________________________________________________________________
+
+#include "Framework/Algorithm/AlgConfigPool.h"
+#include "Framework/Messenger/Messenger.h"
+#include "Physics/Multinucleon/XSection/ScaleMECW.h"
+#include "Framework/Utils/StringUtils.h" 
+#include "Framework/ParticleData/PDGCodes.h"
+#include "Framework/ParticleData/PDGLibrary.h"
+
+using namespace genie;
+
+//_________________________________________________________________________
+ScaleMECW::ScaleMECW() : 
+  Algorithm("genie::ScaleMECW") 
+{
+  
+}
+//_________________________________________________________________________
+ScaleMECW::ScaleMECW(string config) : 
+  Algorithm("genie::ScaleMECW",config) 
+{
+  
+}
+//_________________________________________________________________________
+ScaleMECW::~ScaleMECW()
+{
+
+}
+//_________________________________________________________________________
+void ScaleMECW::Configure(const Registry & config)
+{
+    Algorithm::Configure(config);
+    this->LoadConfig();
+}
+//____________________________________________________________________________
+void ScaleMECW::Configure(string config)
+{
+    Algorithm::Configure(config);
+    this->LoadConfig();
+}
+//_________________________________________________________________________
+double ScaleMECW::GetScaling( double q0, double q3 )
+{
+  // The Scaling is done using the "experimenter's W", which assumes a single nucleon
+  // See motivation in : https://arxiv.org/pdf/1601.02038.pdf
+  double Mn = ( PDGLibrary::Instance()->Find(kPdgProton)->Mass() + PDGLibrary::Instance()->Find(kPdgNeutron)->Mass() ) * 0.5 ;  // Nucleon mass
+
+  // The W1 and W2 limits vary with Q2. They must be updated:
+  fLimits[0] = sqrt( pow(Mn,2) + 2*Mn*fW1_q0q3_limits->Eval(q3) - pow(q3,2) + pow(fW1_q0q3_limits->Eval(q3),2) ) ;
+  fLimits[4] = sqrt( pow(Mn,2) + 2*Mn*q0 ) ; // Imposing Q2 = 0
+   
+  // Calculate event W:
+  double W = sqrt( pow(Mn,2) + 2*Mn*q0 - pow(q0,2) + pow(q0,2) ) ;
+
+  // Calculate scaling:
+
+  for ( unsigned int i = 0 ; i < fWeights.size() - 1 ; ++i ) {
+    if ( W >= fLimits[i] && W < fLimits[i+1] ) {
+      return ScaleFunction( W, fLimits[i], fLimits[i+1], fWeights[i], fWeights[i+1] ) ; 
+    } 
+  }
+
+  return 0; 
+} 
+
+//_________________________________________________________________________
+double ScaleMECW::ScaleFunction( double W, double W_min, double W_max, double scale_min, double scale_max ) const 
+{
+  // This function is responsible to calculate the scale at a given W
+  // It interpolates the value between scale_min (W_min) and scale_max (W_max) linearly 
+
+  double scale = ( W_min * scale_max - W_max * scale_min ) + ( scale_min - scale_max ) * W ;
+  scale /= W_min - W_max ; 
+
+  return scale ; 
+
+} 
+
+//_________________________________________________________________________
+
+void ScaleMECW::LoadConfig(void)
+{
+  double default_weight ; 
+  GetParam( "ScaleMECW-Weight-Default", default_weight ) ;
+  fWeights.assign( 5 , default_weight ) ;
+
+  // Store weights in vector 
+  GetParam( "ScaleMECW-Weight-QELRegion", fWeights[1] ) ;
+  GetParam( "ScaleMECW-Weight-RESRegion", fWeights[3] ) ;
+
+  fLimits.assign( 5 , 0. ) ;
+  // fLimits[0] corresponds to W1. This is obtained from fW1_q0q3_limits 
+  fLimits[1] = ( PDGLibrary::Instance()->Find(kPdgProton)->Mass() + PDGLibrary::Instance()->Find(kPdgNeutron)->Mass() ) * 0.5 ;  // Nucleon mass
+  fLimits[2] = 1.12; // GeV. Value from https://arxiv.org/pdf/1601.02038.pdf // W_dip 
+  fLimits[3] = PDGLibrary::Instance()->Find(kPdgP33m1232_DeltaP)->Mass(); // This corresponds to the Delta mass. 
+  // fLimits[4] satisfies Q2 = 0. 
+
+  // Store spline : ( include this in the xml? ) 
+  // Digitalized from a high stat sample. This is Enu independent.
+  double q0_min[] = { 0.0479, 0.0288, 0.0192, 0.0288, 0.029, 0.0415, 0.0511, 0.0735, 0.1054, 0.1374, 0.1821, 0.2300, 0.2843, 0.3546, 0.4313, 0.4824};
+  double q3_min[] = { 0.054, 0.0963, 0.2139, 0.299, 0.3719, 0.4451, 0.5125, 0.5973, 0.6802, 0.7630, 0.8401, 0.9114, 1.0058, 1.0790, 1.1676, 1.1946};
+
+  TSpline3 * fW1_q0q3_limits = new TSpline3("fW1_q0q3_limits",q3_min,q0_min,16);
+
+}
+
+//_________________________________________________________________________

--- a/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
+++ b/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
@@ -47,15 +47,16 @@ void ScaleMECW::Configure(string config)
     this->LoadConfig();
 }
 //_________________________________________________________________________
-double ScaleMECW::GetScaling( double q0, double q3 )
+double ScaleMECW::GetScaling( double q0, double q3 ) const
 {
   // The Scaling is done using the "experimenter's W", which assumes a single nucleon
   // See motivation in : https://arxiv.org/pdf/1601.02038.pdf
   double Mn = ( PDGLibrary::Instance()->Find(kPdgProton)->Mass() + PDGLibrary::Instance()->Find(kPdgNeutron)->Mass() ) * 0.5 ;  // Nucleon mass
 
+  std::vector<double> limits = fLimits ; 
   // The W1 and W2 limits vary with Q2. They must be updated:
-  fLimits[0] = sqrt( pow(Mn,2) + 2*Mn*fW1_q0q3_limits->Eval(q3) - pow(q3,2) + pow(fW1_q0q3_limits->Eval(q3),2) ) ;
-  fLimits[4] = sqrt( pow(Mn,2) + 2*Mn*q0 ) ; // Imposing Q2 = 0
+  limits[0] = sqrt( pow(Mn,2) + 2*Mn*fW1_q0q3_limits->Eval(q3) - pow(q3,2) + pow(fW1_q0q3_limits->Eval(q3),2) ) ;
+  limits[4] = sqrt( pow(Mn,2) + 2*Mn*q0 ) ; // Imposing Q2 = 0
    
   // Calculate event W:
   double W = sqrt( pow(Mn,2) + 2*Mn*q0 - pow(q0,2) + pow(q0,2) ) ;
@@ -63,8 +64,8 @@ double ScaleMECW::GetScaling( double q0, double q3 )
   // Calculate scaling:
 
   for ( unsigned int i = 0 ; i < fWeights.size() - 1 ; ++i ) {
-    if ( W >= fLimits[i] && W < fLimits[i+1] ) {
-      return ScaleFunction( W, fLimits[i], fLimits[i+1], fWeights[i], fWeights[i+1] ) ; 
+    if ( W >= limits[i] && W < limits[i+1] ) {
+      return ScaleFunction( W, limits[i], limits[i+1], fWeights[i], fWeights[i+1] ) ; 
     } 
   }
 
@@ -89,7 +90,7 @@ double ScaleMECW::ScaleFunction( double W, double W_min, double W_max, double sc
 void ScaleMECW::LoadConfig(void)
 {
   double default_weight ; 
-  GetParam( "ScaleMECW-Weight-Default", default_weight ) ;
+  GetParamDef( "ScaleMECW-Weight-Default", default_weight, 1. ) ;
   fWeights.assign( 5 , default_weight ) ;
 
   // Store weights in vector 
@@ -108,7 +109,7 @@ void ScaleMECW::LoadConfig(void)
   double q0_min[] = { 0.0479, 0.0288, 0.0192, 0.0288, 0.029, 0.0415, 0.0511, 0.0735, 0.1054, 0.1374, 0.1821, 0.2300, 0.2843, 0.3546, 0.4313, 0.4824};
   double q3_min[] = { 0.054, 0.0963, 0.2139, 0.299, 0.3719, 0.4451, 0.5125, 0.5973, 0.6802, 0.7630, 0.8401, 0.9114, 1.0058, 1.0790, 1.1676, 1.1946};
 
-  TSpline3 * fW1_q0q3_limits = new TSpline3("fW1_q0q3_limits",q3_min,q0_min,16);
+  fW1_q0q3_limits = new TSpline3("fW1_q0q3_limits",q3_min,q0_min,16);
 
 }
 

--- a/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
+++ b/src/Physics/Multinucleon/XSection/ScaleMECW.cxx
@@ -69,7 +69,7 @@ double ScaleMECW::GetScaling( const double q0, const double q3 ) const
     } 
   }
 
-  return 0; 
+  return 1. ; 
 } 
 
 //_________________________________________________________________________

--- a/src/Physics/Multinucleon/XSection/ScaleMECW.h
+++ b/src/Physics/Multinucleon/XSection/ScaleMECW.h
@@ -1,0 +1,56 @@
+//____________________________________________________________________________
+/*!
+
+\class    genie::ScaleMECW
+
+\brief    This class is responsible to compute the MEC scaling factor given 
+          q0, q3. The scaling is done as a function of the hadronic invariant
+	  mass.
+
+\author   Code contributed by J.Tena Vidal and M.Roda
+
+\created  June, 2020
+
+\cpright  Copyright (c) 2003-2020, The GENIE Collaboration
+          For the full text of the license visit http://copyright.genie-mc.org
+*/
+//____________________________________________________________________________
+
+#ifndef _SCALE_MEC_W_H_
+#define _SCALE_MEC_W_H_
+
+#include "Framework/Algorithm/Algorithm.h"
+#include <TSpline.h>
+
+using std::map; 
+
+namespace genie {
+  
+  class ScaleMECW: public Algorithm {
+    
+  public:
+    ScaleMECW();
+    ScaleMECW(string config);
+    virtual ~ScaleMECW();
+    
+    virtual double GetScaling( double q0, double q1 ) ; 
+    
+    void Configure (const Registry & config);
+    void Configure (string config);
+    
+  protected:
+    
+    // Load algorithm configuration
+    void LoadConfig (void);
+    
+    virtual double ScaleFunction( double W, double Win, double Wmax, double scale_min, double scale_max ) const ; 
+
+ private: 
+    std::vector<double> fWeights ; 
+    std::vector<double> fLimits ; 
+    TSpline3 * fW1_q0q3_limits ; 
+
+  };
+  
+}       // genie namespace
+#endif  // _SCALE_MEC_W_H_

--- a/src/Physics/Multinucleon/XSection/ScaleMECW.h
+++ b/src/Physics/Multinucleon/XSection/ScaleMECW.h
@@ -33,7 +33,7 @@ namespace genie {
     ScaleMECW(string config);
     virtual ~ScaleMECW();
     
-    virtual double GetScaling( double q0, double q1 ) ; 
+    virtual double GetScaling( double q0, double q3 ) const ; 
     
     void Configure (const Registry & config);
     void Configure (string config);

--- a/src/Physics/Multinucleon/XSection/ScaleMECW.h
+++ b/src/Physics/Multinucleon/XSection/ScaleMECW.h
@@ -33,7 +33,8 @@ namespace genie {
     ScaleMECW(string config);
     virtual ~ScaleMECW();
     
-    virtual double GetScaling( double q0, double q3 ) const ; 
+    // This function returns the scaling value at a given q0 q3:
+    virtual double GetScaling( const double q0, const double q3 ) const ; 
     
     void Configure (const Registry & config);
     void Configure (string config);
@@ -43,7 +44,10 @@ namespace genie {
     // Load algorithm configuration
     void LoadConfig (void);
     
-    virtual double ScaleFunction( double W, double Win, double Wmax, double scale_min, double scale_max ) const ; 
+    // Thist function calculates the scale factor value at W as a linear interpolation
+    // between two W values (Wmin,Wmax) with weights (scale_min,scale_max).
+    virtual double ScaleFunction( double W, double Win, double Wmax, 
+				  double scale_min, double scale_max ) const ; 
 
  private: 
     std::vector<double> fWeights ; 


### PR DESCRIPTION
Things I want to discuss :

1. The main members are two vectors<double> that contain the limits and the weights associated to each limit. The limits are = (W1, Mn, WDip, MDelta, W2) . W1 is given by an array of values that I digitized. W2 is given under the condition Q2 = 0. These values change for each event, therefore, they are set in run time. Mn, WDip and MDelta are set in the configure and are independent of the event. This could be set in the xml file if desired. The weights associated to these are = ( 1., scale_QE, 1, scale_RES, 1).
2. The above implementation requires that there are 5 limits and 5 scaling factors. This could potentially be generalized to any size if we were reading the limits and weights from a vector in the xml file. However, I don't see how we can do this as two of the limits depend on the event kinematics. At the moment I specify that the size is 5, I don't really like that.
3.  The lower limit (W1) is given by an array of values that define q0 and q3. From this I store a TSpline3, which is one of the class members. The limits are coded in the code and not read from the xml file. Do we want to make that an option? Is this approach good enough? 

These are my main concerns at the moment, hopefully it is a starting point. The Nieves class gets the scaling from the public function GetScale. This is the only change needed there.