### PR TITLE
Adding Hadronization paper CMC

### DIFF
--- a/config/G18_02a/G18_02a_03_320/AGKYLowW2019.xml
+++ b/config/G18_02a/G18_02a_03_320/AGKYLowW2019.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!--
+Configuration for the AGKYLowW2019 HadronizationModelI
+
+Algorithm Configurable Parameters:
+.......................................................................................................................
+Name                              Type    Opt   Comment                                       Default
+.......................................................................................................................
+KNO-Alpha-vp                      double  No    a for vp in <mult> = a + blnW^2               KNO-Alpha-vp
+KNO-Alpha-vn                      double  Yes   a for vn                                      KNO-Alpha-vn
+KNO-Alpha-vbp                     double  No    a for vbp                                     KNO-Alpha-vbp
+KNO-Alpha-vbn                     double  No    a for vbn                                     KNO-Alpha-vbn
+KNO-Beta-vp                       double  No    b for vp                                      KNO-Alpha-vp
+KNO-Beta-vn                       double  No    b for vn                                      KNO-Alpha-vn
+KNO-Beta-vbp                      double  No    b for vbp                                     KNO-Alpha-vbp
+KNO-Beta-vbn                      double  No    b for vbn                                     KNO-Alpha-vbn
+KNO-Alpha-Hyperon                 double  No    a in Pstrange = a+blnW^2                      KNO-Alpha-Hyperon
+KNO-Beta-Hyperon                  double  No    b in Pstrange = a+blnW^2                      KNO-Beta-Hyperon
+KNO-LevyC-vp                      double  No    Levy function param c for vp                  KNO-LevyC-vp
+KNO-LevyC-vn                      double  No    Levy function param c for vn                  KNO-LevyC-vn
+KNO-LevyC-vbp                     double  No    Levy function param c for vbp                 KNO-LevyC-vbp
+KNO-LevyC-vbn                     double  No    Levy function param c for vbn                 KNO-LevyC-vbn
+ForceNeugenMultLimit          bool    Yes   force neugen upper multiplicity limit (10)    false
+Wcut                          double  No    W cut in DIS/RES join scheme                      CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m2             double  No    scaling factor, vp  CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m3             double  No    scaling factor, vp  CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m2             double  No    scaling factor, vp  NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m3             double  No    scaling factor, vp  NC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m2             double  No    scaling factor, vn  CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m3             double  No    scaling factor, vn  CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m2             double  No    scaling factor, vn  NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m3             double  No    scaling factor, vn  NC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m2            double  No    scaling factor, vbp CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m3            double  No    scaling factor, vbp CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m2            double  No    scaling factor, vbp NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m3            double  No    scaling factor, vbp NC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m2            double  No    scaling factor, vbn CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m3            double  No    scaling factor, vbn CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m2            double  No    scaling factor, vbn NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m3            double  No    scaling factor, vbn NC, multiplicity=3 CommonParam[NonResBackground]
+KNO-ProbPi0Pi0                    double  No    probability for pi0 pair                      KNO-ProbPi0Pi0
+KNO-ProbPiplusPiminus             double  No    probability for pi+pi- pair                   KNO-ProbPiplusPiminus
+KNO-ProbKplusKminus               double  No    probability for K+K- pair                     KNO-ProbKplusKminus
+KNO-ProbK0K0bar                   double  No    probability for K0 K0bar pair                 KNO-ProbK0K0bar
+KNO-ProbPi0Eta                    double  No    probability for Pi0 Eta pair                  KNO-ProbPi0Eta
+KNO-ProbEtaEta                    double  No    Probability for Eta Eta pair                  KNO-ProbEtaEta
+ForceDecays                   bool    Yes   force decays of unstable particles            false   
+Decayer                       alg     Dep   decayer to be used if decayes are forced
+ForceMinMultiplicity          bool    Yes   force a minimum multiplicity of 2             true
+GenerateWeighted              bool    Yes   generate weighted events                      false
+KNO-UseBaryonPdfs-xFpT2           bool    Yes   use a baryon pT^2, xF parameterization        KNO-UseBaryonPdfs-xFpT2
+KNO-UseIsotropic2BodyDec          bool    Yes   use isotropic, non-reweighted 2-body decays   KNO-UseIsotropic2BodyDec
+                                            for compatibility with neuugen/daikon
+KNO-PhaseSpDec-Reweight           bool    Yes   reweight decays to to reproduce exp pT2       KNO-PhaseSpDec-Reweight
+KNO-PhaseSpDec-ReweightParm       double  Yes   parameter controlling the reweight function   KNO-PhaseSpDec-ReweightParm
+-->
+
+<alg_conf>
+  <param_set name="Default"> 
+    
+    <param type="string" name="CommonParam">  NonResBackground </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the average charged hadron multiplicities in the AGKY/KNO model
+	 (paramerers a,b entering in the empirical expression: <n> = a + b * lnW^2 )
+	 See Nucl.Instrum.Meth.A614:87-104,2010 and Eur.Phys.J.C63:1-10,2009. 
+    -->
+    <param type="double" name="KNO-Alpha-vp">  1.2  </param> 
+    <param type="double" name="KNO-Alpha-vn">  -0.58 </param> 
+    <param type="double" name="KNO-Alpha-vbp"> 1.9 </param> 
+    <param type="double" name="KNO-Alpha-vbn"> 1.07 </param> 
+    <param type="double" name="KNO-Beta-vp">   0.9 </param> 
+    <param type="double" name="KNO-Beta-vn">   1.9  </param> 
+    <param type="double" name="KNO-Beta-vbp">  0.3  </param> 
+    <param type="double" name="KNO-Beta-vbn">  0.9 </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the probability of producing a strange baryon via associated production.
+	 (paramerers a,b entering in the empirical expression: P_{hyperon} = a + b * lnW^2 )
+	 Determined from a fit to \Lambda production data.
+	 See Nucl.Instrum.Meth.A614:87-104,2010 and Eur.Phys.J.C63:1-10,2009. 
+    -->
+    <param type="double" name="KNO-Alpha-Hyperon"> 0.021951447 </param> 
+    <param type="double" name="KNO-Beta-Hyperon">  0.041969985 </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Levy function (KNO parameterization) parameter c at kno(z) = 2*exp(-c)*pow(c,cz+1)/Gamma(cz+1)
+	 v+p    : 7.93 +/- 0.34 source: Tingjun's fit
+	 v+n    : 5.22 +/- 0.15 source: Tingjun's fit
+	 vbar+p : same as vn
+	 vbar+n : same as vp
+    -->
+    <param type="double" name="KNO-LevyC-vp">  7.93 </param> 
+    <param type="double" name="KNO-LevyC-vn">  5.22 </param> 
+    <param type="double" name="KNO-LevyC-vbp"> 5.22 </param> 
+    <param type="double" name="KNO-LevyC-vbn"> 7.93 </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 AGKY/KNO hadronization model probabilities for producing hadron pairs.
+	 See Nucl.Instrum.Meth.A614:87-104,2010 and Eur.Phys.J.C63:1-10,2009. 
+	 Values below are modified values following strange hadron production tuning (see gDocDB-890-v1).
+	 Previous values were P(pi0 pi0) = 0.30, P(pi+ pi-) = 0.60, P(K+ K-) = 0.05, P(K0 \barK0) = 0.05.
+    -->
+    <param type="double" name="KNO-ProbPi0Pi0">        0.3133 </param>
+    <param type="double" name="KNO-ProbPiplusPiminus"> 0.6267 </param>
+    <param type="double" name="KNO-ProbKplusKminus">   0.03 </param>
+    <param type="double" name="KNO-ProbK0K0bar">       0.03 </param>
+    <param type="double" name="KNO-ProbPi0Eta">        0.0 </param> 
+    <param type="double" name="KNO-ProbEtaEta">        0.0   </param>
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling whether to reweight the KNO phase space decay reweighting and the actual
+	 reweighting function.
+	 See: A.B.Clegg, A.Donnachie, A Description of Jet Structure by pT-limited Phase Space.
+    -->
+    <param type="bool"   name="KNO-PhaseSpDec-Reweight">     true  </param>
+    <param type="double" name="KNO-PhaseSpDec-ReweightParm"> 3.5   </param> 
+    
+     <!-- 
+	  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	  Parameters controlling whether to use the baryon xF and pT2 pdfs in the KNO hadronization.
+	  The option to use isotropic, non-reweighted 2-body phase space decays is used for compatibility
+	  with neugen/daikon.
+     -->
+     <param type="bool" name="KNO-UseBaryonPdfs-xFpT2">  true  </param>
+     <param type="bool" name="KNO-UseIsotropic2BodyDec"> true  </param>
+
+  </param_set>
+  
+  <param_set name="Default-Decaying"> 
+    <param type="bool" name="ForceDecays">  true                            </param>
+    <param type="alg"  name="Decayer">      genie::PythiaDecayer/Default    </param>
+  </param_set>
+  
+  <param_set name="Old"> 
+     <param type="bool" name="KNO-UseBaryonPdfs-xFpT2">  false  </param>
+     <param type="bool" name="KNO-PhaseSpDec-Reweight">  false  </param>
+  </param_set>
+
+  <param_set name="Old-Decaying"> 
+     <param type="bool" name="ForceDecays">           true                            </param>
+     <param type="alg"  name="Decayer">               genie::PythiaDecayer/Default    </param>
+     <param type="bool" name="KNO-UseBaryonPdfs-xFpT2">   false                           </param>
+     <param type="bool" name="KNO-PhaseSpDec-Reweight">   false                           </param>
+  </param_set>
+
+</alg_conf>
+

--- a/config/G18_02a/G18_02a_03_320/CommonParam.xml
+++ b/config/G18_02a/G18_02a_03_320/CommonParam.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!--
+***************************************************************************************************
+This file defines parameters sets for parameters which are common between algorithms and therefore
+has to be the same for those parameters to be meaningful.
+This is file is read from the AlgConfigPool and the parameters set are expected to be used by the
+algorithms to configure these common parameters.
+
+Author:
+Costas Andreopoulos <constantinos.andreopoulos \at cern.ch>
+STFC, Rutherford Appleton Laboratory
+
+and
+Marco Roda <marco.roda \at liverpool.ac.uk>
+University of Liverpool
+***************************************************************************************************
+-->
+
+
+
+<common_Param_list>
+
+
+  <param_set name="Tunable">
+    <!-- Reserved register for tuning -->
+    <param type="double" name="RES-Ma">  1.088962  </param>
+    <param type="double" name="DIS-XSecScale"> 1.062213 </param>
+    <param type="double" name="RES-CC-XSecScale"> 0.838730 </param>
+  </param_set>
+
+  <param_set name="KNO2Pythia">
+    <!--                                                                                                              
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~            
+         Invariant mass window for the transition from KNO model to PYTHIA                                            
+    -->
+
+    <param type="double" name="KNO2PYTHIA-Wmin">  2.30 </param>
+    <param type="double" name="KNO2PYTHIA-Wmax">  3.00 </param>
+
+  </param_set>
+
+  <param_set name="WeakInt">
+    <param type="double" name="WeinbergAngle"> 0.501716712132 </param> <!-- 0.501568 -->
+
+  </param_set>
+
+  <param_set name="StrongInt">
+    <param type="double" name="SU3-D"> 0.804 </param>
+    <param type="double" name="SU3-F"> 0.463 </param>
+
+  </param_set>
+
+
+  <param_set name="CKM">
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 CKM quark mixing parameters
+	 Chinese Physics C Vol.40, No. 10 (2016) 100001
+	 Review of Particle Physics
+    -->
+    <param type="double" name="CKM-Vud">  0.97417  </param>
+    <param type="double" name="CKM-Vus">  0.2248   </param>
+    <param type="double" name="CKM-Vcd">  0.220    </param>  <!-- 0.2239 -->
+    <param type="double" name="CKM-Vcs">  0.995    </param>
+
+    <param type="double" name="CabibboAngle">  0.227780466682 </param> <!-- 0.226893 -->
+
+  </param_set>
+
+  <param_set name="NUCL">
+
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 NUCL-Ro (in fm) is a scale parameter driving the effective nuclear sizes (Ro in R=Ro*A^1/3)
+    -->
+    <param type="double" name="NUCL-R0"> 1.4 </param>
+    <param type="double" name="NUCL-NR"> 3.0 </param>
+
+  </param_set>
+
+  <param_set name="Masses">
+    <param type="double" name="Charm-Mass"> 1.430  </param> <!-- GeV -->
+  </param_set>
+
+
+  <param_set name="NonResBackground">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RES/DIS joining scheme
+	At this point there is a single scheme, the one originally developed in neugen3.
+	For W >  Wcut : RES -> 0,   +  DIS                -> full
+	For W <= Wcut : RES -> full + `DIS' (non-RES bkg) -> modified by DIS-HMultWgt-* params
+	-
+	- ...
+
+    -->
+    <param type="bool"   name="UseDRJoinScheme"> true </param>
+    <param type="double" name="Wcut"> 1.809000 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	NEUGEN parameters applied to DIS hadronic multiplicity distributions
+	to avoid 2-ble counting with RES
+    -->
+    <param type="double" name="DIS-HMultWgt-vp-CC-m2">  0.008 </param>
+    <param type="double" name="DIS-HMultWgt-vp-CC-m3">  0.943153 </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m2">  0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m2">  0.030802 </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m3">  2.338338 </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m2">  0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m2"> 0.030802 </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m3"> 2.338338 </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m2"> 0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m2"> 0.008 </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m3"> 0.943153 </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m2"> 0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m3"> 1.000  </param>
+
+  </param_set>
+
+
+  <param_set name="FermiGas">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Parameters related with GENIE's Fermi Gas (RFG) model implementation
+	- RFG-Momentum-CutOff is a momentum cut-off for the NN correlation tail
+	- RFG-NucRemovalE@Pdg=10LZZZAAAI is the removal energy for the nucleus with the specified pdg
+	code. If none is used then the average binding energy will be computed from Wapstra's semi-
+	empirical formula.
+	Currently, if you explicitly specify a binding energy for a nucleus then the same value will
+	be used for all isotopes.
+    -->
+    <param type="double" name="RFG-MomentumCutOff">              0.5000 </param>
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000030060">  0.0170 </param> <!-- Li6    -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000060120">  0.0250 </param> <!-- C12    -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000080160">  0.0270 </param> <!-- O16    -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000120240">  0.0320 </param> <!-- Mg24   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000180400">  0.0295 </param> <!-- Ar40   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000200400">  0.0280 </param> <!-- Ca40   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000220480">  0.0300 </param> <!-- Ti48  -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000260560">  0.0360 </param> <!-- Fe56   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000280580">  0.0360 </param> <!-- Ni58   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000822080">  0.0440 </param> <!-- Pb208  -->
+    <param type="bool"   name="RFG-UseParametrization">          false  </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Table of Fermi momentum (kF) constants for various nuclei
+	The tables can be found in $GENIE/config/FermiMomentumTables.xml
+    -->
+    <param type="string" name="FermiMomentumTable"> Default </param>
+
+  </param_set>
+
+
+  <!--
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      INTRANUKE-specific parameters:
+      - Mode options are: hA, hN
+      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
+      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
+
+Probably these should all be moved in the local configurations
+  -->
+
+  <param_set name="INUKE">
+    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
+    <param type="double" name="INUKE-HadStep">           0.05  </param>
+    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
+    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
+    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
+    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
+    <param type="double" name="INUKE-FermiFac">          1.0   </param>
+    <param type="double" name="INUKE-FreeStep">          0.0   </param>
+    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
+    <param type="bool"   name="INUKE-DoFermi">           true  </param>
+    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
+    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
+  </param_set>
+
+  <param_set name="HAINUKE">
+    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
+    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
+  </param_set>
+
+  <param_set name="HNINUKE">
+    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
+    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
+    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
+  </param_set>
+
+  <param_set name="Coherent">
+
+    <param type="double" name="COH-Ro"> 1.000 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Minimum and maximum considered Q^2 for Berger-Sehgal coherent reactions when estimating
+	the max cross section.
+	Units in GeV^2.
+    -->
+    <param type="double" name="COH-Q2-min"> 0.000 </param>
+    <param type="double" name="COH-Q2-max"> 1.000 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Maximum considered t for Berger-Sehgal coherent reactions when estimating the
+	max cross section.
+	Units in GeV^2.
+    -->
+    <param type="double" name="COH-t-max"> 0.250 </param>
+
+  </param_set>
+
+
+  <param_set name="Diffractive">
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Slope parameter beta for diffractive scattering (GeV^-2) (b ~ 0.333 * nucleon_size^2)
+    -->
+    <param type="double" name="DFR-Beta"> 7.0 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Maximum considered t for diffractive scattering reactions when estimating the max cross section.
+	Units in GeV^2.
+
+This value is read in KpHase space!!! It's mental, but we have to be careful before removing this
+Or changing the name of this parameter set
+    -->
+    <param type="double" name="DFR-t-max"> 0.35 </param>
+
+  </param_set>
+
+  <param_set name="QuasiElastic">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Value of axial form factor at Q2=0
+    -->
+    <param type="double" name="QEL-FA0"> -1.2670 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Axial and vector masses for quasi-elastic scattering
+    -->
+    <param type="double" name="QEL-Ma"> 0.994989 </param>
+    <param type="double" name="QEL-Mv"> 0.840 </param>
+
+  </param_set>
+
+  <param_set name="MagnMoments">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Proton and neutron anomalous magnetic moments
+    -->
+    <param type="double" name="AnomMagnMoment-P">   2.7930     </param> <!-- 2.7928473 -->
+    <param type="double" name="AnomMagnMoment-N">  -1.913042   </param>
+
+  </param_set>
+
+  <param_set name="MultiNucleons">
+    <!--  Q3 max for 2p2h model    -->
+    <param type="double" name="NSV-Q3Max"> 1.2 </param>
+  </param_set>
+
+  <param_set name="ElasticFF">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Elastic form factors used for QEL CC cross section calculation.
+	Options are:
+	- genie::DipoleELFormFactorsModel
+	- genie::BBA03ELFormFactorsModel, H.Budd, NuINT-02 proceedings
+	- genie::BBA05ELFormFactorsModel, R.Bradford, A.Bodek, H.Budd and J.Arrington, hep-ex/0602017
+	- genie::BBA07ELFormFactorsModel, R.Bradford, A.Bodek, H.Budd and S.Avvakumov, Euro.Phys.J.C53 (2008);[arXiv:0708.1946 [hep-ex]]
+    -->
+    <param type="alg" name="ElasticFormFactorsModel"> genie::BBA07ELFormFactorsModel/Default </param>
+
+    <!-- Option for turning on Transverse Enhancement by Elastic Form Factor adjustment.
+	 See http://arxiv.org/abs/1405.0583 and http://arxiv.org/abs/1106.0340
+    -->
+    <param type="bool" name="UseElFFTransverseEnhancement">  false                              </param>
+    <param type="alg" name="TransverseEnhancement"> genie::TransverseEnhancementFFModel/Default </param>
+
+  </param_set>
+
+  <param_set name="Resonances">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Default list of baryon resonances included in cross section models and generation threads
+    -->
+    <param type="string" name="ResonanceNameList">
+      P33(1232),S11(1535),D13(1520),S11(1650),D13(1700),D15(1675),
+      S31(1620),D33(1700),P11(1440),P33(1600),P13(1720),F15(1680),
+      P31(1910),P33(1920),F35(1905),F37(1950),P11(1710)
+    </param>
+
+
+    <!--
+	In this configuration set we include only the first two resonances
+	<param type="string" name="ResonanceNameList">    P33(1232),P11(1440)       </param>
+    -->
+
+
+  </param_set>
+
+  <param_set name="Lepton">
+    <param type="bool" name="ApplyCoulombCorrection"> false </param>
+
+  </param_set>
+
+  <param_set name="Validation">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	GENIE validity range
+    -->
+    <param type="double" name="GVLD-Emin">    0.010  </param>
+    <param type="double" name="GVLD-Emax"> 1000.000  </param>
+
+  </param_set>
+
+</common_Param_list>

--- a/config/G18_02a/G18_02a_03_320/Pythia6Hadro2019.xml
+++ b/config/G18_02a/G18_02a_03_320/Pythia6Hadro2019.xml
@@ -87,20 +87,20 @@ KNO2PYTHIA-Wmin                 double  No    Validity checks with Wcut         
 	 NEUGEN parameters applied to DIS hadronic multiplicity distributions 
 	 to avoid 2-ble counting with RES
     -->
-    <param type="double" name="DIS-HMultWgt-vp-CC-m2">  0.100  </param>
-    <param type="double" name="DIS-HMultWgt-vp-CC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vp-CC-m2">  0.008 </param>
+    <param type="double" name="DIS-HMultWgt-vp-CC-m3">  0.943153 </param>
     <param type="double" name="DIS-HMultWgt-vp-NC-m2">  0.100  </param>
     <param type="double" name="DIS-HMultWgt-vp-NC-m3">  1.000  </param>
-    <param type="double" name="DIS-HMultWgt-vn-CC-m2">  0.300  </param>
-    <param type="double" name="DIS-HMultWgt-vn-CC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m2">  0.030802 </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m3">  2.338338 </param>
     <param type="double" name="DIS-HMultWgt-vn-NC-m2">  0.300  </param>
     <param type="double" name="DIS-HMultWgt-vn-NC-m3">  1.000  </param>
-    <param type="double" name="DIS-HMultWgt-vbp-CC-m2"> 0.300  </param>
-    <param type="double" name="DIS-HMultWgt-vbp-CC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m2"> 0.030802 </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m3"> 2.338338 </param>
     <param type="double" name="DIS-HMultWgt-vbp-NC-m2"> 0.300  </param>
     <param type="double" name="DIS-HMultWgt-vbp-NC-m3"> 1.000  </param>
-    <param type="double" name="DIS-HMultWgt-vbn-CC-m2"> 0.100  </param>
-    <param type="double" name="DIS-HMultWgt-vbn-CC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m2"> 0.008 </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m3"> 0.943153 </param>
     <param type="double" name="DIS-HMultWgt-vbn-NC-m2"> 0.100  </param>
     <param type="double" name="DIS-HMultWgt-vbn-NC-m3"> 1.000  </param>
     

--- a/config/G18_02a/G18_02a_03_320/Pythia6Hadro2019.xml
+++ b/config/G18_02a/G18_02a_03_320/Pythia6Hadro2019.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<alg_conf>
+
+<!--
+Configuration for the PYTHIA hadronization model
+
+Configurable Parameters:
+................................................................................................................................
+Name                            Type    Opt   Comment (see PYTHIA manual)                              Default 
+................................................................................................................................
+PYTHIA-SSBarSuppression         double  No    PYTHIA's PARJ(2): the suppression of s quark pair        //
+                                              production in the field compared with u,d production
+PYTHIA-GaussianPt2              double  No    PYTHIA's PARJ(21): corresponds to the width sigma in     //
+                                              the gaussian transverse momentum distribution for
+                                              primary hadrons
+PYTHIA-NonGaussianPt2Tail       double  No    PYTHIA's PARJ(23): param used to model non-gaussian      //
+                                              pt2 tails
+PYTHIA-RemainingEnergyCutoff    double  No    PYTHIA's PARJ(33): param used to define the remaining    //
+                                              energy below which the fragmentation of a parton system
+                                              is stopped and two final hadrons formed
+PYTHIA-DiQuarkSuppression       double  No    PYTHIA's PARJ(1): Di quark supression                    //
+
+PYTHIA-LightVMesonSuppression   double  No    PYTHIA's PARJ(11): Light vector meson suppression        //
+
+PYTHIA-SVMesonSuppression       double  No    PYTHIA's PARJ(12): Strange vector meson suppression      //
+
+PYTHIA-Lunda                    double  No    PYTHIA's PARJ(41): Lund a parameter                      //
+
+PYTHIA-Lundb                    double  No    PYTHIA's PARJ(42): Lund b parameter                      //
+
+PYTHIA-LundaDiq                 double  No    PYTHIA's PARJ(45): Lund a di quark parameter             //
+
+Wcut                            double  No    W cut in DIS/RES join scheme                             CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m2           double  No    scaling factor, vp  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m3           double  No    scaling factor, vp  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m2           double  No    scaling factor, vp  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m3           double  No    scaling factor, vp  NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m2           double  No    scaling factor, vn  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m3           double  No    scaling factor, vn  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m2           double  No    scaling factor, vn  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m3           double  No    scaling factor, vn  NC, multiplicity=3                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-CC-m2          double  No    scaling factor, vbp CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m3          double  No    scaling factor, vbp CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m2          double  No    scaling factor, vbp NC, multiplicity=2                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-NC-m3          double  No    scaling factor, vbp NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m2          double  No    scaling factor, vbn CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m3          double  No    scaling factor, vbn CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m2          double  No    scaling factor, vbn NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m3          double  No    scaling factor, vbn NC, multiplicity=3                   CommonParam[NonResBackground] 
+Decayer                         alg     Yes   particle decayer algorithm in case of -manual- decays    -unused-
+KNO2PYTHIA-Wmin                 double  No    Validity checks with Wcut                                CommonParam[KNO2Pythia]        
+-->
+
+<!-- 
+  Default PYTHIA 
+-->
+  <param_set name="Default"> 
+
+    <param type="string" name="CommonParam"> NonResBackground,KNO2Pythia </param> 
+
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the PYTHIA hadronization model:
+	 
+         PYTHIA    NUX 2001   AGKY 2010 strange prod.
+         default   tune       re-tune (see gDocDB-890-v1)
+	 - ssbar:   0.30      0.21       0.30
+	 - pt2:     0.36 GeV  0.44 GeV
+	 - pt2tail: 0.01      0.01    
+	 - cutoff:  0.80 GeV  0.20 GeV
+    -->
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.29 </param>
+    <param type="double" name="PYTHIA-GaussianPt2">           0.43 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param>
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.24 </param>
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 1.85 </param>
+    <param type="double" name="PYTHIA-Lundb"> 1.0 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 NEUGEN parameters applied to DIS hadronic multiplicity distributions 
+	 to avoid 2-ble counting with RES
+    -->
+    <param type="double" name="DIS-HMultWgt-vp-CC-m2">  0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vp-CC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m2">  0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m2">  0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m2">  0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m2"> 0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m2"> 0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m2"> 0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m2"> 0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m3"> 1.000  </param>
+    
+  </param_set>
+  
+<!-- 
+  Standard PYTHIA
+-->
+  <param_set name="Standard"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.30 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.36 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.80 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+<!-- 
+  Tuned parameters as used by NUX (see A.Rubbia's talk @ NuINT01) 
+-->
+  <param_set name="NUX"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.21 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.44 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.20 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+</alg_conf>
+

--- a/config/G18_02a/G18_02a_03_320/Pythia8Hadro2019.xml
+++ b/config/G18_02a/G18_02a_03_320/Pythia8Hadro2019.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<alg_conf>
+
+<!--
+Configuration for the PYTHIA hadronization model
+
+Configurable Parameters:
+................................................................................................................................
+Name                            Type    Opt   Comment (see PYTHIA manual)                              Default 
+................................................................................................................................
+PYTHIA-SSBarSuppression         double  No    PYTHIA's PARJ(2): the suppression of s quark pair        //
+                                              production in the field compared with u,d production
+PYTHIA-GaussianPt2              double  No    PYTHIA's PARJ(21): corresponds to the width sigma in     //
+                                              the gaussian transverse momentum distribution for
+                                              primary hadrons
+PYTHIA-NonGaussianPt2Tail       double  No    PYTHIA's PARJ(23): param used to model non-gaussian      //
+                                              pt2 tails
+PYTHIA-RemainingEnergyCutoff    double  No    PYTHIA's PARJ(33): param used to define the remaining    //
+                                              energy below which the fragmentation of a parton system
+                                              is stopped and two final hadrons formed
+PYTHIA-DiQuarkSuppression       double  No    PYTHIA's PARJ(1): Di quark supression                    //
+
+PYTHIA-LightVMesonSuppression   double  No    PYTHIA's PARJ(11): Light vector meson suppression        //
+
+PYTHIA-SVMesonSuppression       double  No    PYTHIA's PARJ(12): Strange vector meson suppression      //
+
+PYTHIA-Lunda                    double  No    PYTHIA's PARJ(41): Lund a parameter                      //
+
+PYTHIA-Lundb                    double  No    PYTHIA's PARJ(42): Lund b parameter                      //
+
+PYTHIA-LundaDiq                 double  No    PYTHIA's PARJ(45): Lund a di quark parameter             //
+
+Wcut                            double  No    W cut in DIS/RES join scheme                             CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m2           double  No    scaling factor, vp  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m3           double  No    scaling factor, vp  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m2           double  No    scaling factor, vp  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m3           double  No    scaling factor, vp  NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m2           double  No    scaling factor, vn  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m3           double  No    scaling factor, vn  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m2           double  No    scaling factor, vn  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m3           double  No    scaling factor, vn  NC, multiplicity=3                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-CC-m2          double  No    scaling factor, vbp CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m3          double  No    scaling factor, vbp CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m2          double  No    scaling factor, vbp NC, multiplicity=2                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-NC-m3          double  No    scaling factor, vbp NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m2          double  No    scaling factor, vbn CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m3          double  No    scaling factor, vbn CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m2          double  No    scaling factor, vbn NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m3          double  No    scaling factor, vbn NC, multiplicity=3                   CommonParam[NonResBackground] 
+Decayer                         alg     Yes   particle decayer algorithm in case of -manual- decays    -unused-
+KNO2PYTHIA-Wmin                 double  No    Validity checks with Wcut                                CommonParam[KNO2Pythia]        
+-->
+
+<!-- 
+  Default PYTHIA 
+-->
+  <param_set name="Default"> 
+
+    <param type="string" name="CommonParam"> NonResBackground,KNO2Pythia </param> 
+
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the PYTHIA hadronization model:
+	 
+         PYTHIA    NUX 2001   AGKY 2010 strange prod.
+         default   tune       re-tune (see gDocDB-890-v1)
+	 - ssbar:   0.30      0.21       0.30
+	 - pt2:     0.36 GeV  0.44 GeV
+	 - pt2tail: 0.01      0.01    
+	 - cutoff:  0.80 GeV  0.20 GeV
+    -->
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.29 </param>
+    <param type="double" name="PYTHIA-GaussianPt2">           0.43 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param>
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.24 </param>
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 1.85 </param>
+    <param type="double" name="PYTHIA-Lundb"> 1.0 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+  
+<!-- 
+  Standard PYTHIA
+-->
+  <param_set name="Standard"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.30 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.36 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.80 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+<!-- 
+  Tuned parameters as used by NUX (see A.Rubbia's talk @ NuINT01) 
+-->
+  <param_set name="NUX"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.21 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.44 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.20 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+</alg_conf>
+

--- a/config/G18_02a/G18_02a_03_330/AGKYLowW2019.xml
+++ b/config/G18_02a/G18_02a_03_330/AGKYLowW2019.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!--
+Configuration for the AGKYLowW2019 HadronizationModelI
+
+Algorithm Configurable Parameters:
+.......................................................................................................................
+Name                              Type    Opt   Comment                                       Default
+.......................................................................................................................
+KNO-Alpha-vp                      double  No    a for vp in <mult> = a + blnW^2               KNO-Alpha-vp
+KNO-Alpha-vn                      double  Yes   a for vn                                      KNO-Alpha-vn
+KNO-Alpha-vbp                     double  No    a for vbp                                     KNO-Alpha-vbp
+KNO-Alpha-vbn                     double  No    a for vbn                                     KNO-Alpha-vbn
+KNO-Beta-vp                       double  No    b for vp                                      KNO-Alpha-vp
+KNO-Beta-vn                       double  No    b for vn                                      KNO-Alpha-vn
+KNO-Beta-vbp                      double  No    b for vbp                                     KNO-Alpha-vbp
+KNO-Beta-vbn                      double  No    b for vbn                                     KNO-Alpha-vbn
+KNO-Alpha-Hyperon                 double  No    a in Pstrange = a+blnW^2                      KNO-Alpha-Hyperon
+KNO-Beta-Hyperon                  double  No    b in Pstrange = a+blnW^2                      KNO-Beta-Hyperon
+KNO-LevyC-vp                      double  No    Levy function param c for vp                  KNO-LevyC-vp
+KNO-LevyC-vn                      double  No    Levy function param c for vn                  KNO-LevyC-vn
+KNO-LevyC-vbp                     double  No    Levy function param c for vbp                 KNO-LevyC-vbp
+KNO-LevyC-vbn                     double  No    Levy function param c for vbn                 KNO-LevyC-vbn
+ForceNeugenMultLimit          bool    Yes   force neugen upper multiplicity limit (10)    false
+Wcut                          double  No    W cut in DIS/RES join scheme                      CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m2             double  No    scaling factor, vp  CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m3             double  No    scaling factor, vp  CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m2             double  No    scaling factor, vp  NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m3             double  No    scaling factor, vp  NC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m2             double  No    scaling factor, vn  CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m3             double  No    scaling factor, vn  CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m2             double  No    scaling factor, vn  NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m3             double  No    scaling factor, vn  NC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m2            double  No    scaling factor, vbp CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m3            double  No    scaling factor, vbp CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m2            double  No    scaling factor, vbp NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m3            double  No    scaling factor, vbp NC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m2            double  No    scaling factor, vbn CC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m3            double  No    scaling factor, vbn CC, multiplicity=3 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m2            double  No    scaling factor, vbn NC, multiplicity=2 CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m3            double  No    scaling factor, vbn NC, multiplicity=3 CommonParam[NonResBackground]
+KNO-ProbPi0Pi0                    double  No    probability for pi0 pair                      KNO-ProbPi0Pi0
+KNO-ProbPiplusPiminus             double  No    probability for pi+pi- pair                   KNO-ProbPiplusPiminus
+KNO-ProbKplusKminus               double  No    probability for K+K- pair                     KNO-ProbKplusKminus
+KNO-ProbK0K0bar                   double  No    probability for K0 K0bar pair                 KNO-ProbK0K0bar
+KNO-ProbPi0Eta                    double  No    probability for Pi0 Eta pair                  KNO-ProbPi0Eta
+KNO-ProbEtaEta                    double  No    Probability for Eta Eta pair                  KNO-ProbEtaEta
+ForceDecays                   bool    Yes   force decays of unstable particles            false   
+Decayer                       alg     Dep   decayer to be used if decayes are forced
+ForceMinMultiplicity          bool    Yes   force a minimum multiplicity of 2             true
+GenerateWeighted              bool    Yes   generate weighted events                      false
+KNO-UseBaryonPdfs-xFpT2           bool    Yes   use a baryon pT^2, xF parameterization        KNO-UseBaryonPdfs-xFpT2
+KNO-UseIsotropic2BodyDec          bool    Yes   use isotropic, non-reweighted 2-body decays   KNO-UseIsotropic2BodyDec
+                                            for compatibility with neuugen/daikon
+KNO-PhaseSpDec-Reweight           bool    Yes   reweight decays to to reproduce exp pT2       KNO-PhaseSpDec-Reweight
+KNO-PhaseSpDec-ReweightParm       double  Yes   parameter controlling the reweight function   KNO-PhaseSpDec-ReweightParm
+-->
+
+<alg_conf>
+  <param_set name="Default"> 
+    
+    <param type="string" name="CommonParam">  NonResBackground </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the average charged hadron multiplicities in the AGKY/KNO model
+	 (paramerers a,b entering in the empirical expression: <n> = a + b * lnW^2 )
+	 See Nucl.Instrum.Meth.A614:87-104,2010 and Eur.Phys.J.C63:1-10,2009. 
+    -->
+    <param type="double" name="KNO-Alpha-vp">  1.1  </param> 
+    <param type="double" name="KNO-Alpha-vn">  1.75 </param> 
+    <param type="double" name="KNO-Alpha-vbp"> 1.32 </param> 
+    <param type="double" name="KNO-Alpha-vbn"> 1.11 </param> 
+    <param type="double" name="KNO-Beta-vp">   0.79 </param> 
+    <param type="double" name="KNO-Beta-vn">   0.5  </param> 
+    <param type="double" name="KNO-Beta-vbp">  0.8  </param> 
+    <param type="double" name="KNO-Beta-vbn">  0.88 </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the probability of producing a strange baryon via associated production.
+	 (paramerers a,b entering in the empirical expression: P_{hyperon} = a + b * lnW^2 )
+	 Determined from a fit to \Lambda production data.
+	 See Nucl.Instrum.Meth.A614:87-104,2010 and Eur.Phys.J.C63:1-10,2009. 
+    -->
+    <param type="double" name="KNO-Alpha-Hyperon"> 0.021951447 </param> 
+    <param type="double" name="KNO-Beta-Hyperon">  0.041969985 </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Levy function (KNO parameterization) parameter c at kno(z) = 2*exp(-c)*pow(c,cz+1)/Gamma(cz+1)
+	 v+p    : 7.93 +/- 0.34 source: Tingjun's fit
+	 v+n    : 5.22 +/- 0.15 source: Tingjun's fit
+	 vbar+p : same as vn
+	 vbar+n : same as vp
+    -->
+    <param type="double" name="KNO-LevyC-vp">  7.93 </param> 
+    <param type="double" name="KNO-LevyC-vn">  5.22 </param> 
+    <param type="double" name="KNO-LevyC-vbp"> 5.22 </param> 
+    <param type="double" name="KNO-LevyC-vbn"> 7.93 </param> 
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 AGKY/KNO hadronization model probabilities for producing hadron pairs.
+	 See Nucl.Instrum.Meth.A614:87-104,2010 and Eur.Phys.J.C63:1-10,2009. 
+	 Values below are modified values following strange hadron production tuning (see gDocDB-890-v1).
+	 Previous values were P(pi0 pi0) = 0.30, P(pi+ pi-) = 0.60, P(K+ K-) = 0.05, P(K0 \barK0) = 0.05.
+    -->
+    <param type="double" name="KNO-ProbPi0Pi0">        0.3133 </param>
+    <param type="double" name="KNO-ProbPiplusPiminus"> 0.6267 </param>
+    <param type="double" name="KNO-ProbKplusKminus">   0.03 </param>
+    <param type="double" name="KNO-ProbK0K0bar">       0.03 </param>
+    <param type="double" name="KNO-ProbPi0Eta">        0.0 </param> 
+    <param type="double" name="KNO-ProbEtaEta">        0.0   </param>
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling whether to reweight the KNO phase space decay reweighting and the actual
+	 reweighting function.
+	 See: A.B.Clegg, A.Donnachie, A Description of Jet Structure by pT-limited Phase Space.
+    -->
+    <param type="bool"   name="KNO-PhaseSpDec-Reweight">     true  </param>
+    <param type="double" name="KNO-PhaseSpDec-ReweightParm"> 3.5   </param> 
+    
+     <!-- 
+	  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	  Parameters controlling whether to use the baryon xF and pT2 pdfs in the KNO hadronization.
+	  The option to use isotropic, non-reweighted 2-body phase space decays is used for compatibility
+	  with neugen/daikon.
+     -->
+     <param type="bool" name="KNO-UseBaryonPdfs-xFpT2">  true  </param>
+     <param type="bool" name="KNO-UseIsotropic2BodyDec"> true  </param>
+
+  </param_set>
+  
+  <param_set name="Default-Decaying"> 
+    <param type="bool" name="ForceDecays">  true                            </param>
+    <param type="alg"  name="Decayer">      genie::PythiaDecayer/Default    </param>
+  </param_set>
+  
+  <param_set name="Old"> 
+     <param type="bool" name="KNO-UseBaryonPdfs-xFpT2">  false  </param>
+     <param type="bool" name="KNO-PhaseSpDec-Reweight">  false  </param>
+  </param_set>
+
+  <param_set name="Old-Decaying"> 
+     <param type="bool" name="ForceDecays">           true                            </param>
+     <param type="alg"  name="Decayer">               genie::PythiaDecayer/Default    </param>
+     <param type="bool" name="KNO-UseBaryonPdfs-xFpT2">   false                           </param>
+     <param type="bool" name="KNO-PhaseSpDec-Reweight">   false                           </param>
+  </param_set>
+
+</alg_conf>
+

--- a/config/G18_02a/G18_02a_03_330/CommonParam.xml
+++ b/config/G18_02a/G18_02a_03_330/CommonParam.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!--
+***************************************************************************************************
+This file defines parameters sets for parameters which are common between algorithms and therefore
+has to be the same for those parameters to be meaningful.
+This is file is read from the AlgConfigPool and the parameters set are expected to be used by the
+algorithms to configure these common parameters.
+
+Author:
+Costas Andreopoulos <constantinos.andreopoulos \at cern.ch>
+STFC, Rutherford Appleton Laboratory
+
+and
+Marco Roda <marco.roda \at liverpool.ac.uk>
+University of Liverpool
+***************************************************************************************************
+-->
+
+
+
+<common_Param_list>
+
+
+  <param_set name="Tunable">
+    <!-- Reserved register for tuning -->
+    <param type="double" name="RES-Ma">  1.088962  </param>
+    <param type="double" name="DIS-XSecScale"> 1.062213 </param>
+    <param type="double" name="RES-CC-XSecScale"> 0.838730 </param>
+  </param_set>
+
+  <param_set name="KNO2Pythia">
+    <!--                                                                                                              
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~            
+         Invariant mass window for the transition from KNO model to PYTHIA                                            
+    -->
+
+    <param type="double" name="KNO2PYTHIA-Wmin">  2.30 </param>
+    <param type="double" name="KNO2PYTHIA-Wmax">  3.00 </param>
+
+  </param_set>
+
+  <param_set name="WeakInt">
+    <param type="double" name="WeinbergAngle"> 0.501716712132 </param> <!-- 0.501568 -->
+
+  </param_set>
+
+  <param_set name="StrongInt">
+    <param type="double" name="SU3-D"> 0.804 </param>
+    <param type="double" name="SU3-F"> 0.463 </param>
+
+  </param_set>
+
+
+  <param_set name="CKM">
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 CKM quark mixing parameters
+	 Chinese Physics C Vol.40, No. 10 (2016) 100001
+	 Review of Particle Physics
+    -->
+    <param type="double" name="CKM-Vud">  0.97417  </param>
+    <param type="double" name="CKM-Vus">  0.2248   </param>
+    <param type="double" name="CKM-Vcd">  0.220    </param>  <!-- 0.2239 -->
+    <param type="double" name="CKM-Vcs">  0.995    </param>
+
+    <param type="double" name="CabibboAngle">  0.227780466682 </param> <!-- 0.226893 -->
+
+  </param_set>
+
+  <param_set name="NUCL">
+
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 NUCL-Ro (in fm) is a scale parameter driving the effective nuclear sizes (Ro in R=Ro*A^1/3)
+    -->
+    <param type="double" name="NUCL-R0"> 1.4 </param>
+    <param type="double" name="NUCL-NR"> 3.0 </param>
+
+  </param_set>
+
+  <param_set name="Masses">
+    <param type="double" name="Charm-Mass"> 1.430  </param> <!-- GeV -->
+  </param_set>
+
+
+  <param_set name="NonResBackground">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RES/DIS joining scheme
+	At this point there is a single scheme, the one originally developed in neugen3.
+	For W >  Wcut : RES -> 0,   +  DIS                -> full
+	For W <= Wcut : RES -> full + `DIS' (non-RES bkg) -> modified by DIS-HMultWgt-* params
+	-
+	- ...
+
+    -->
+    <param type="bool"   name="UseDRJoinScheme"> true </param>
+    <param type="double" name="Wcut"> 1.809000 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	NEUGEN parameters applied to DIS hadronic multiplicity distributions
+	to avoid 2-ble counting with RES
+    -->
+    <param type="double" name="DIS-HMultWgt-vp-CC-m2">  0.008 </param>
+    <param type="double" name="DIS-HMultWgt-vp-CC-m3">  0.943153 </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m2">  0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m2">  0.030802 </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m3">  2.338338 </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m2">  0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m2"> 0.030802 </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m3"> 2.338338 </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m2"> 0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m2"> 0.008 </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m3"> 0.943153 </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m2"> 0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m3"> 1.000  </param>
+
+  </param_set>
+
+
+  <param_set name="FermiGas">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Parameters related with GENIE's Fermi Gas (RFG) model implementation
+	- RFG-Momentum-CutOff is a momentum cut-off for the NN correlation tail
+	- RFG-NucRemovalE@Pdg=10LZZZAAAI is the removal energy for the nucleus with the specified pdg
+	code. If none is used then the average binding energy will be computed from Wapstra's semi-
+	empirical formula.
+	Currently, if you explicitly specify a binding energy for a nucleus then the same value will
+	be used for all isotopes.
+    -->
+    <param type="double" name="RFG-MomentumCutOff">              0.5000 </param>
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000030060">  0.0170 </param> <!-- Li6    -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000060120">  0.0250 </param> <!-- C12    -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000080160">  0.0270 </param> <!-- O16    -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000120240">  0.0320 </param> <!-- Mg24   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000180400">  0.0295 </param> <!-- Ar40   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000200400">  0.0280 </param> <!-- Ca40   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000220480">  0.0300 </param> <!-- Ti48  -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000260560">  0.0360 </param> <!-- Fe56   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000280580">  0.0360 </param> <!-- Ni58   -->
+    <param type="double" name="RFG-NucRemovalE@Pdg=1000822080">  0.0440 </param> <!-- Pb208  -->
+    <param type="bool"   name="RFG-UseParametrization">          false  </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Table of Fermi momentum (kF) constants for various nuclei
+	The tables can be found in $GENIE/config/FermiMomentumTables.xml
+    -->
+    <param type="string" name="FermiMomentumTable"> Default </param>
+
+  </param_set>
+
+
+  <!--
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      INTRANUKE-specific parameters:
+      - Mode options are: hA, hN
+      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
+      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
+
+Probably these should all be moved in the local configurations
+  -->
+
+  <param_set name="INUKE">
+    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
+    <param type="double" name="INUKE-HadStep">           0.05  </param>
+    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
+    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
+    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
+    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
+    <param type="double" name="INUKE-FermiFac">          1.0   </param>
+    <param type="double" name="INUKE-FreeStep">          0.0   </param>
+    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
+    <param type="bool"   name="INUKE-DoFermi">           true  </param>
+    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
+    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
+  </param_set>
+
+  <param_set name="HAINUKE">
+    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
+    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
+  </param_set>
+
+  <param_set name="HNINUKE">
+    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
+    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
+    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
+  </param_set>
+
+  <param_set name="Coherent">
+
+    <param type="double" name="COH-Ro"> 1.000 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Minimum and maximum considered Q^2 for Berger-Sehgal coherent reactions when estimating
+	the max cross section.
+	Units in GeV^2.
+    -->
+    <param type="double" name="COH-Q2-min"> 0.000 </param>
+    <param type="double" name="COH-Q2-max"> 1.000 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Maximum considered t for Berger-Sehgal coherent reactions when estimating the
+	max cross section.
+	Units in GeV^2.
+    -->
+    <param type="double" name="COH-t-max"> 0.250 </param>
+
+  </param_set>
+
+
+  <param_set name="Diffractive">
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Slope parameter beta for diffractive scattering (GeV^-2) (b ~ 0.333 * nucleon_size^2)
+    -->
+    <param type="double" name="DFR-Beta"> 7.0 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Maximum considered t for diffractive scattering reactions when estimating the max cross section.
+	Units in GeV^2.
+
+This value is read in KpHase space!!! It's mental, but we have to be careful before removing this
+Or changing the name of this parameter set
+    -->
+    <param type="double" name="DFR-t-max"> 0.35 </param>
+
+  </param_set>
+
+  <param_set name="QuasiElastic">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Value of axial form factor at Q2=0
+    -->
+    <param type="double" name="QEL-FA0"> -1.2670 </param>
+
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Axial and vector masses for quasi-elastic scattering
+    -->
+    <param type="double" name="QEL-Ma"> 0.994989 </param>
+    <param type="double" name="QEL-Mv"> 0.840 </param>
+
+  </param_set>
+
+  <param_set name="MagnMoments">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Proton and neutron anomalous magnetic moments
+    -->
+    <param type="double" name="AnomMagnMoment-P">   2.7930     </param> <!-- 2.7928473 -->
+    <param type="double" name="AnomMagnMoment-N">  -1.913042   </param>
+
+  </param_set>
+
+  <param_set name="MultiNucleons">
+    <!--  Q3 max for 2p2h model    -->
+    <param type="double" name="NSV-Q3Max"> 1.2 </param>
+  </param_set>
+
+  <param_set name="ElasticFF">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Elastic form factors used for QEL CC cross section calculation.
+	Options are:
+	- genie::DipoleELFormFactorsModel
+	- genie::BBA03ELFormFactorsModel, H.Budd, NuINT-02 proceedings
+	- genie::BBA05ELFormFactorsModel, R.Bradford, A.Bodek, H.Budd and J.Arrington, hep-ex/0602017
+	- genie::BBA07ELFormFactorsModel, R.Bradford, A.Bodek, H.Budd and S.Avvakumov, Euro.Phys.J.C53 (2008);[arXiv:0708.1946 [hep-ex]]
+    -->
+    <param type="alg" name="ElasticFormFactorsModel"> genie::BBA07ELFormFactorsModel/Default </param>
+
+    <!-- Option for turning on Transverse Enhancement by Elastic Form Factor adjustment.
+	 See http://arxiv.org/abs/1405.0583 and http://arxiv.org/abs/1106.0340
+    -->
+    <param type="bool" name="UseElFFTransverseEnhancement">  false                              </param>
+    <param type="alg" name="TransverseEnhancement"> genie::TransverseEnhancementFFModel/Default </param>
+
+  </param_set>
+
+  <param_set name="Resonances">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Default list of baryon resonances included in cross section models and generation threads
+    -->
+    <param type="string" name="ResonanceNameList">
+      P33(1232),S11(1535),D13(1520),S11(1650),D13(1700),D15(1675),
+      S31(1620),D33(1700),P11(1440),P33(1600),P13(1720),F15(1680),
+      P31(1910),P33(1920),F35(1905),F37(1950),P11(1710)
+    </param>
+
+
+    <!--
+	In this configuration set we include only the first two resonances
+	<param type="string" name="ResonanceNameList">    P33(1232),P11(1440)       </param>
+    -->
+
+
+  </param_set>
+
+  <param_set name="Lepton">
+    <param type="bool" name="ApplyCoulombCorrection"> false </param>
+
+  </param_set>
+
+  <param_set name="Validation">
+    <!--
+	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	GENIE validity range
+    -->
+    <param type="double" name="GVLD-Emin">    0.010  </param>
+    <param type="double" name="GVLD-Emax"> 1000.000  </param>
+
+  </param_set>
+
+</common_Param_list>

--- a/config/G18_02a/G18_02a_03_330/Pythia6Hadro2019.xml
+++ b/config/G18_02a/G18_02a_03_330/Pythia6Hadro2019.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<alg_conf>
+
+<!--
+Configuration for the PYTHIA hadronization model
+
+Configurable Parameters:
+................................................................................................................................
+Name                            Type    Opt   Comment (see PYTHIA manual)                              Default 
+................................................................................................................................
+PYTHIA-SSBarSuppression         double  No    PYTHIA's PARJ(2): the suppression of s quark pair        //
+                                              production in the field compared with u,d production
+PYTHIA-GaussianPt2              double  No    PYTHIA's PARJ(21): corresponds to the width sigma in     //
+                                              the gaussian transverse momentum distribution for
+                                              primary hadrons
+PYTHIA-NonGaussianPt2Tail       double  No    PYTHIA's PARJ(23): param used to model non-gaussian      //
+                                              pt2 tails
+PYTHIA-RemainingEnergyCutoff    double  No    PYTHIA's PARJ(33): param used to define the remaining    //
+                                              energy below which the fragmentation of a parton system
+                                              is stopped and two final hadrons formed
+PYTHIA-DiQuarkSuppression       double  No    PYTHIA's PARJ(1): Di quark supression                    //
+
+PYTHIA-LightVMesonSuppression   double  No    PYTHIA's PARJ(11): Light vector meson suppression        //
+
+PYTHIA-SVMesonSuppression       double  No    PYTHIA's PARJ(12): Strange vector meson suppression      //
+
+PYTHIA-Lunda                    double  No    PYTHIA's PARJ(41): Lund a parameter                      //
+
+PYTHIA-Lundb                    double  No    PYTHIA's PARJ(42): Lund b parameter                      //
+
+PYTHIA-LundaDiq                 double  No    PYTHIA's PARJ(45): Lund a di quark parameter             //
+
+Wcut                            double  No    W cut in DIS/RES join scheme                             CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m2           double  No    scaling factor, vp  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m3           double  No    scaling factor, vp  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m2           double  No    scaling factor, vp  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m3           double  No    scaling factor, vp  NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m2           double  No    scaling factor, vn  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m3           double  No    scaling factor, vn  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m2           double  No    scaling factor, vn  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m3           double  No    scaling factor, vn  NC, multiplicity=3                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-CC-m2          double  No    scaling factor, vbp CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m3          double  No    scaling factor, vbp CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m2          double  No    scaling factor, vbp NC, multiplicity=2                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-NC-m3          double  No    scaling factor, vbp NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m2          double  No    scaling factor, vbn CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m3          double  No    scaling factor, vbn CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m2          double  No    scaling factor, vbn NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m3          double  No    scaling factor, vbn NC, multiplicity=3                   CommonParam[NonResBackground] 
+Decayer                         alg     Yes   particle decayer algorithm in case of -manual- decays    -unused-
+KNO2PYTHIA-Wmin                 double  No    Validity checks with Wcut                                CommonParam[KNO2Pythia]        
+-->
+
+<!-- 
+  Default PYTHIA 
+-->
+  <param_set name="Default"> 
+
+    <param type="string" name="CommonParam"> NonResBackground,KNO2Pythia </param> 
+
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the PYTHIA hadronization model:
+	 
+         PYTHIA    NUX 2001   AGKY 2010 strange prod.
+         default   tune       re-tune (see gDocDB-890-v1)
+	 - ssbar:   0.30      0.21       0.30
+	 - pt2:     0.36 GeV  0.44 GeV
+	 - pt2tail: 0.01      0.01    
+	 - cutoff:  0.80 GeV  0.20 GeV
+    -->
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.27 </param>
+    <param type="double" name="PYTHIA-GaussianPt2">           0.43 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param>
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.30 </param>
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 1.53 </param>
+    <param type="double" name="PYTHIA-Lundb"> 1.16 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 NEUGEN parameters applied to DIS hadronic multiplicity distributions 
+	 to avoid 2-ble counting with RES
+    -->
+    <param type="double" name="DIS-HMultWgt-vp-CC-m2">  0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vp-CC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m2">  0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vp-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m2">  0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vn-CC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m2">  0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vn-NC-m3">  1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m2"> 0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-CC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m2"> 0.300  </param>
+    <param type="double" name="DIS-HMultWgt-vbp-NC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m2"> 0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-CC-m3"> 1.000  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m2"> 0.100  </param>
+    <param type="double" name="DIS-HMultWgt-vbn-NC-m3"> 1.000  </param>
+    
+  </param_set>
+  
+<!-- 
+  Standard PYTHIA
+-->
+  <param_set name="Standard"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.30 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.36 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.80 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+<!-- 
+  Tuned parameters as used by NUX (see A.Rubbia's talk @ NuINT01) 
+-->
+  <param_set name="NUX"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.21 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.44 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.20 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+</alg_conf>
+

--- a/config/G18_02a/G18_02a_03_330/Pythia8Hadro2019.xml
+++ b/config/G18_02a/G18_02a_03_330/Pythia8Hadro2019.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<alg_conf>
+
+<!--
+Configuration for the PYTHIA hadronization model
+
+Configurable Parameters:
+................................................................................................................................
+Name                            Type    Opt   Comment (see PYTHIA manual)                              Default 
+................................................................................................................................
+PYTHIA-SSBarSuppression         double  No    PYTHIA's PARJ(2): the suppression of s quark pair        //
+                                              production in the field compared with u,d production
+PYTHIA-GaussianPt2              double  No    PYTHIA's PARJ(21): corresponds to the width sigma in     //
+                                              the gaussian transverse momentum distribution for
+                                              primary hadrons
+PYTHIA-NonGaussianPt2Tail       double  No    PYTHIA's PARJ(23): param used to model non-gaussian      //
+                                              pt2 tails
+PYTHIA-RemainingEnergyCutoff    double  No    PYTHIA's PARJ(33): param used to define the remaining    //
+                                              energy below which the fragmentation of a parton system
+                                              is stopped and two final hadrons formed
+PYTHIA-DiQuarkSuppression       double  No    PYTHIA's PARJ(1): Di quark supression                    //
+
+PYTHIA-LightVMesonSuppression   double  No    PYTHIA's PARJ(11): Light vector meson suppression        //
+
+PYTHIA-SVMesonSuppression       double  No    PYTHIA's PARJ(12): Strange vector meson suppression      //
+
+PYTHIA-Lunda                    double  No    PYTHIA's PARJ(41): Lund a parameter                      //
+
+PYTHIA-Lundb                    double  No    PYTHIA's PARJ(42): Lund b parameter                      //
+
+PYTHIA-LundaDiq                 double  No    PYTHIA's PARJ(45): Lund a di quark parameter             //
+
+Wcut                            double  No    W cut in DIS/RES join scheme                             CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m2           double  No    scaling factor, vp  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-CC-m3           double  No    scaling factor, vp  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m2           double  No    scaling factor, vp  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vp-NC-m3           double  No    scaling factor, vp  NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m2           double  No    scaling factor, vn  CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-CC-m3           double  No    scaling factor, vn  CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m2           double  No    scaling factor, vn  NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vn-NC-m3           double  No    scaling factor, vn  NC, multiplicity=3                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-CC-m2          double  No    scaling factor, vbp CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-CC-m3          double  No    scaling factor, vbp CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbp-NC-m2          double  No    scaling factor, vbp NC, multiplicity=2                   CommonParam[NonResBackground] 
+DIS-HMultWgt-vbp-NC-m3          double  No    scaling factor, vbp NC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m2          double  No    scaling factor, vbn CC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-CC-m3          double  No    scaling factor, vbn CC, multiplicity=3                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m2          double  No    scaling factor, vbn NC, multiplicity=2                   CommonParam[NonResBackground]
+DIS-HMultWgt-vbn-NC-m3          double  No    scaling factor, vbn NC, multiplicity=3                   CommonParam[NonResBackground] 
+Decayer                         alg     Yes   particle decayer algorithm in case of -manual- decays    -unused-
+KNO2PYTHIA-Wmin                 double  No    Validity checks with Wcut                                CommonParam[KNO2Pythia]        
+-->
+
+<!-- 
+  Default PYTHIA 
+-->
+  <param_set name="Default"> 
+
+    <param type="string" name="CommonParam"> NonResBackground,KNO2Pythia </param> 
+
+    
+    <!-- 
+	 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	 Parameters controlling the PYTHIA hadronization model:
+	 
+         PYTHIA    NUX 2001   AGKY 2010 strange prod.
+         default   tune       re-tune (see gDocDB-890-v1)
+	 - ssbar:   0.30      0.21       0.30
+	 - pt2:     0.36 GeV  0.44 GeV
+	 - pt2tail: 0.01      0.01    
+	 - cutoff:  0.80 GeV  0.20 GeV
+    -->
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.27 </param>
+    <param type="double" name="PYTHIA-GaussianPt2">           0.43 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param>
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.30 </param>
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 1.53 </param>
+    <param type="double" name="PYTHIA-Lundb"> 1.16 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+
+  </param_set>
+  
+<!-- 
+  Standard PYTHIA
+-->
+  <param_set name="Standard"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.30 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.36 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.80 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+<!-- 
+  Tuned parameters as used by NUX (see A.Rubbia's talk @ NuINT01) 
+-->
+  <param_set name="NUX"> 
+    <param type="double" name="PYTHIA-SSBarSuppression">      0.21 </param> 
+    <param type="double" name="PYTHIA-GaussianPt2">           0.44 </param> 
+    <param type="double" name="PYTHIA-NonGaussianPt2Tail">    0.01 </param> 
+    <param type="double" name="PYTHIA-RemainingEnergyCutoff"> 0.20 </param> 
+    <param type="double" name="PYTHIA-DiQuarkSuppression"> 0.10 </param>
+    <param type="double" name="PYTHIA-LightVMesonSuppression"> 0.50 </param>
+    <param type="double" name="PYTHIA-SVMesonSuppression"> 0.60 </param>
+    <param type="double" name="PYTHIA-Lunda"> 0.30 </param>
+    <param type="double" name="PYTHIA-Lundb"> 0.58 </param>
+    <param type="double" name="PYTHIA-LundaDiq"> 0.5 </param>
+  </param_set>
+
+</alg_conf>
+


### PR DESCRIPTION
In this pull request, the different CMC containing the results from the hadronization paper are handled. So far I added the configurations for the G18_02a only.