### PR TITLE
Develop/fsi reweight

### DIFF
--- a/config/CascadeReweight.xml
+++ b/config/CascadeReweight.xml
@@ -5,17 +5,47 @@
 <!--
 Configuration sets for the CascadeReweight EventRecordVisitorI
 
+..............................................................................................................
 Configurable Parameters:
-............................................................................................
-Name         Type     Optional   Comment                     Default
-............................................................................................
-
-
+..............................................................................................................
+Name                                 Type     Optional   Comment                                  Default
+..............................................................................................................
+CascadeReweight-Default-Weight       double   No         Default weight associated to a FSI fate
+CascadeReweight-Weight-Undefined     double   Yes        Weight associated to the undefined fate
+CascadeReweight-Weight-NoInteraction double   Yes        Weight associated to the nointeraction fate
+CascadeReweight-Weight-CEx           double   Yes        Weight associated to the CEx fate
+CascadeReweight-Weight-Elastic       double   Yes        Weight associated to the Elastic fate
+CascadeReweight-Weight-Inelastic     double   Yes        Weight associated to the Inelastic fate
+CascadeReweight-Weight-Abs           double   Yes        Weight associated to the Abs fate
+CascadeReweight-Weight-Cmp           double   Yes        Weight associated to the Cmp fate
+..............................................................................................................
 -->
 
   <param_set name="Default"> 
-
+    <param type="double"  name="CascadeReweight-Default-Weight"> 1. </param>   
   </param_set>
+  
+  <param_set name="PionReweight">
+    <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-CEx@Pdg=211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Abs@Pdg=211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Elastic@Pdg=211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Inelastic@Pdg=211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Cmp@Pdg=211"> 1. </param>
+  </param_set>
+
+  <param_set name="ProtonReweight">
+    <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=2212"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=2212"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-CEx@Pdg=2212"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Abs@Pdg=2212"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Elastic@Pdg=2212"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Inelastic@Pdg=2212"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Cmp@Pdg=2212"> 1. </param>
+  </param_set>
+
+  <!-- Add other combinations here -->
 
 </alg_conf>
 

--- a/config/CascadeReweight.xml
+++ b/config/CascadeReweight.xml
@@ -27,8 +27,19 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
 
   <param_set name="Default"> 
   </param_set>
+
+  <param_set name="FatesReweight"> 
+    <param type="double" name="CascadeReweight-Weight-Undefined"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-NoInteraction"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-CEx"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Abs"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Elastic"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Inelastic"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Cmp"> 1. </param>
+  </param_set>
   
   <param_set name="PionReweight">
+    <!--piplus-->
     <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-CEx@Pdg=211"> 1. </param>
@@ -36,6 +47,23 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
     <param type="double" name="CascadeReweight-Weight-Elastic@Pdg=211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-Inelastic@Pdg=211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-Cmp@Pdg=211"> 1. </param>
+    <!--pimin-->    
+    <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=-211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=-211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-CEx@Pdg=-211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Abs@Pdg=-211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Elastic@Pdg=-211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Inelastic@Pdg=-211"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Cmp@Pdg=-211"> 1. </param>
+    <!--pi0-->
+    <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=111"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=111"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-CEx@Pdg=111"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Abs@Pdg=111"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Elastic@Pdg=111"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Inelastic@Pdg=111"> 1. </param>
+    <param type="double" name="CascadeReweight-Weight-Cmp@Pdg=111"> 1. </param>
+
   </param_set>
 
   <param_set name="ProtonReweight">

--- a/config/CascadeReweight.xml
+++ b/config/CascadeReweight.xml
@@ -20,7 +20,7 @@ CascadeReweight-Weight-Abs           double   Yes        Weight associated to th
 CascadeReweight-Weight-Cmp           double   Yes        Weight associated to the Cmp fate
 ..............................................................................................................
 For the CascadeReweight-Weight-Fate parameters, we can assign a weight to all particles with a given fate, 
-or specify a particular pdg by setting @Pdg= after the string.
+CascadeReweight-Default-Weight-Fate parameters, or specify a particular pdg by setting @Pdg= after the string.
 If not specified, the default is CascadeReweight-Default-Weight for all fates.
 ..............................................................................................................
 -->
@@ -29,13 +29,13 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
   </param_set>
 
   <param_set name="FatesReweight"> 
-    <param type="double" name="CascadeReweight-Weight-Undefined"> 1. </param>
-    <param type="double" name="CascadeReweight-Weight-NoInteraction"> 1. </param>
-    <param type="double" name="CascadeReweight-Weight-CEx"> 1. </param>
-    <param type="double" name="CascadeReweight-Weight-Abs"> 1. </param>
-    <param type="double" name="CascadeReweight-Weight-Elastic"> 1. </param>
-    <param type="double" name="CascadeReweight-Weight-Inelastic"> 1. </param>
-    <param type="double" name="CascadeReweight-Weight-Cmp"> 1. </param>
+    <param type="double" name="CascadeReweight-Default-Weight-Undefined"> 1. </param>
+    <param type="double" name="CascadeReweight-Default-Weight-NoInteraction"> 1. </param>
+    <param type="double" name="CascadeReweight-Default-Weight-CEx"> 1. </param>
+    <param type="double" name="CascadeReweight-Default-Weight-Abs"> 1. </param>
+    <param type="double" name="CascadeReweight-Default-Weight-Elastic"> 1. </param>
+    <param type="double" name="CascadeReweight-Default-Weight-Inelastic"> 1. </param>
+    <param type="double" name="CascadeReweight-Default-Weight-Cmp"> 1. </param>
   </param_set>
   
   <param_set name="PionReweight">

--- a/config/CascadeReweight.xml
+++ b/config/CascadeReweight.xml
@@ -10,7 +10,7 @@ Configurable Parameters:
 ..............................................................................................................
 Name                                 Type     Optional   Comment                                  Default
 ..............................................................................................................
-CascadeReweight-Default-Weight       double   No         Default weight associated to a FSI fate
+CascadeReweight-Default-Weight       double   Yes        Default weight associated to a FSI fate  1.
 CascadeReweight-Weight-Undefined     double   Yes        Weight associated to the undefined fate
 CascadeReweight-Weight-NoInteraction double   Yes        Weight associated to the nointeraction fate
 CascadeReweight-Weight-CEx           double   Yes        Weight associated to the CEx fate
@@ -19,10 +19,13 @@ CascadeReweight-Weight-Inelastic     double   Yes        Weight associated to th
 CascadeReweight-Weight-Abs           double   Yes        Weight associated to the Abs fate
 CascadeReweight-Weight-Cmp           double   Yes        Weight associated to the Cmp fate
 ..............................................................................................................
+For the CascadeReweight-Weight-Fate parameters, we can assign a weight to all particles with a given fate, 
+or specify a particular pdg by setting @Pdg= after the string.
+If not specified, the default is CascadeReweight-Default-Weight for all fates.
+..............................................................................................................
 -->
 
   <param_set name="Default"> 
-    <param type="double"  name="CascadeReweight-Default-Weight"> 1. </param>   
   </param_set>
   
   <param_set name="PionReweight">

--- a/config/CascadeReweight.xml
+++ b/config/CascadeReweight.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<alg_conf>
+
+<!--
+Configuration sets for the CascadeReweight EventRecordVisitorI
+
+Configurable Parameters:
+............................................................................................
+Name         Type     Optional   Comment                     Default
+............................................................................................
+
+
+-->
+
+  <param_set name="Default"> 
+
+  </param_set>
+
+</alg_conf>
+

--- a/config/CascadeReweight.xml
+++ b/config/CascadeReweight.xml
@@ -10,8 +10,6 @@ Configurable Parameters:
 ..............................................................................................................
 Name                                 Type     Optional   Comment                                  Default
 ..............................................................................................................
-CascadeReweight-Default-Weight       double   Yes        Default weight associated to a FSI fate  1.
-CascadeReweight-Weight-Undefined     double   Yes        Weight associated to the undefined fate
 CascadeReweight-Weight-NoInteraction double   Yes        Weight associated to the nointeraction fate
 CascadeReweight-Weight-CEx           double   Yes        Weight associated to the CEx fate
 CascadeReweight-Weight-Elastic       double   Yes        Weight associated to the Elastic fate
@@ -19,9 +17,8 @@ CascadeReweight-Weight-Inelastic     double   Yes        Weight associated to th
 CascadeReweight-Weight-Abs           double   Yes        Weight associated to the Abs fate
 CascadeReweight-Weight-Cmp           double   Yes        Weight associated to the Cmp fate
 ..............................................................................................................
-For the CascadeReweight-Weight-Fate parameters, we can assign a weight to all particles with a given fate, 
-CascadeReweight-Default-Weight-Fate parameters, or specify a particular pdg by setting @Pdg= after the string.
-If not specified, the default is CascadeReweight-Default-Weight for all fates.
+CascadeReweight-Default-Weight-Fate parameters, or specify the weight for a specific incoming particle 
+(pion, proton, etc) by setting @Pdg= after the string.
 ..............................................................................................................
 -->
 
@@ -29,7 +26,6 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
   </param_set>
 
   <param_set name="FatesReweight"> 
-    <param type="double" name="CascadeReweight-Default-Weight-Undefined"> 1. </param>
     <param type="double" name="CascadeReweight-Default-Weight-NoInteraction"> 1. </param>
     <param type="double" name="CascadeReweight-Default-Weight-CEx"> 1. </param>
     <param type="double" name="CascadeReweight-Default-Weight-Abs"> 1. </param>
@@ -39,7 +35,6 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
   </param_set>
   
   <param_set name="PionReweight">
-    <!--piplus-->
     <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-CEx@Pdg=211"> 1. </param>
@@ -48,7 +43,6 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
     <param type="double" name="CascadeReweight-Weight-Inelastic@Pdg=211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-Cmp@Pdg=211"> 1. </param>
     <!--pimin-->    
-    <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=-211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=-211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-CEx@Pdg=-211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-Abs@Pdg=-211"> 1. </param>
@@ -56,7 +50,6 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
     <param type="double" name="CascadeReweight-Weight-Inelastic@Pdg=-211"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-Cmp@Pdg=-211"> 1. </param>
     <!--pi0-->
-    <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=111"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=111"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-CEx@Pdg=111"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-Abs@Pdg=111"> 1. </param>
@@ -67,7 +60,6 @@ If not specified, the default is CascadeReweight-Default-Weight for all fates.
   </param_set>
 
   <param_set name="ProtonReweight">
-    <param type="double" name="CascadeReweight-Weight-Undefined@Pdg=2212"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-NoInteraction@Pdg=2212"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-CEx@Pdg=2212"> 1. </param>
     <param type="double" name="CascadeReweight-Weight-Abs@Pdg=2212"> 1. </param>

--- a/config/CascadeReweight.xml
+++ b/config/CascadeReweight.xml
@@ -20,12 +20,12 @@ CascadeReweight-Weight-Cmp           double   Yes        Weight associated to th
 CascadeReweight-Default-Weight-Fate parameters, or specify the weight for a specific incoming particle 
 (pion, proton, etc) by setting @Pdg= after the string.
 ..............................................................................................................
+This configuration file is used for tuning purposes only.
+The present configurations are here only as an example.
+..............................................................................................................
 -->
 
   <param_set name="Default"> 
-  </param_set>
-
-  <param_set name="FatesReweight"> 
     <param type="double" name="CascadeReweight-Default-Weight-NoInteraction"> 1. </param>
     <param type="double" name="CascadeReweight-Default-Weight-CEx"> 1. </param>
     <param type="double" name="CascadeReweight-Default-Weight-Abs"> 1. </param>

--- a/config/master_config.xml
+++ b/config/master_config.xml
@@ -11,6 +11,7 @@
    <config alg="genie::HNIntranuke2018">                 HNIntranuke2018.xml                 </config>
    <config alg="genie::HINCLCascadeIntranuke">           HINCLCascadeIntranuke.xml           </config>
    <config alg="genie::HG4BertCascIntranuke">            HG4BertCascIntranuke.xml            </config>
+   <config alg="genie::CascadeReweight">                 CascadeReweight.xml                 </config>
    <config alg="genie::UnstableParticleDecayer">         UnstableParticleDecayer.xml         </config>
    <config alg="genie::PauliBlocker">                    PauliBlocker.xml                    </config>
    <config alg="genie::NucDeExcitationSim">              NucDeExcitationSim.xml              </config>

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -108,8 +108,7 @@ void CascadeReweight::LoadConfig(void) {
 
   // Create vector with list of possible keys (follows the order of the fates
   // enumeration)
-  std::map<INukeFateHN_t, string> EINukeFate_map_keys =
-      INukeHadroFates::GetEINukeFateKeysMap();
+  std::map<INukeFateHN_t, string> EINukeFate_map_keys = GetEINukeFateKeysMap();
 
   for (map<INukeFateHN_t, string>::iterator it_keys =
            EINukeFate_map_keys.begin();

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -2,9 +2,9 @@
 /*
  Copyright (c) 2003-2020, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
+
  Julia Tena-Vidal <j.tena-vidal \at liverpool.ac.uk>
- University of Liverpool 
+ University of Liverpool
 
 */
 //____________________________________________________________________________
@@ -14,165 +14,161 @@
 #include "Framework/Algorithm/AlgConfigPool.h"
 #include "Framework/Algorithm/AlgFactory.h"
 #include "Framework/Conventions/Constants.h"
-#include "Physics/HadronTransport/CascadeReweight.h"
-#include "Framework/GHEP/GHepStatus.h"
-#include "Framework/GHEP/GHepRecord.h"
 #include "Framework/GHEP/GHepParticle.h"
+#include "Framework/GHEP/GHepRecord.h"
+#include "Framework/GHEP/GHepStatus.h"
 #include "Framework/Interaction/Interaction.h"
 #include "Framework/Messenger/Messenger.h"
 #include "Framework/Numerical/RandomGen.h"
 #include "Framework/ParticleData/PDGUtils.h"
 #include "Framework/Utils/PrintUtils.h"
+#include "Physics/HadronTransport/CascadeReweight.h"
 #include "Physics/NuclearState/NuclearUtils.h"
 
-#include "Framework/Utils/StringUtils.h" 
 #include "Framework/ParticleData/PDGLibrary.h"
 #include "Framework/ParticleData/PDGUtils.h"
+#include "Framework/Utils/StringUtils.h"
 
 using namespace genie;
 using namespace genie::utils;
 using namespace genie::constants;
 
 //___________________________________________________________________________
-CascadeReweight::CascadeReweight() :
-EventRecordVisitorI("genie::CascadeReweight")
-{
-
-}
+CascadeReweight::CascadeReweight()
+    : EventRecordVisitorI("genie::CascadeReweight") {}
 //___________________________________________________________________________
-CascadeReweight::CascadeReweight(string config) :
-EventRecordVisitorI("genie::CascadeReweight", config)
-{
-
-}
+CascadeReweight::CascadeReweight(string config)
+    : EventRecordVisitorI("genie::CascadeReweight", config) {}
 //___________________________________________________________________________
-CascadeReweight::~CascadeReweight()
-{
-
-}
+CascadeReweight::~CascadeReweight() {}
 //___________________________________________________________________________
-void CascadeReweight::ProcessEventRecord(GHepRecord * evrec) const
-{
-  if( !evrec ){
-    LOG("CascadeReweight", pERROR) << "** Null input!" ;
-    return ; 
+void CascadeReweight::ProcessEventRecord(GHepRecord *evrec) const {
+  if (!evrec) {
+    LOG("CascadeReweight", pERROR) << "** Null input!";
+    return;
   }
   // Get Associated weight
-  double weight = GetEventWeight( * evrec ) ;
-  // Set weight 
-  evrec->SetWeight( weight ) ;
+  double weight = GetEventWeight(*evrec);
+  // Set weight
+  evrec->SetWeight(weight);
 
-  return ;
+  return;
 }
 //___________________________________________________________________________
-double CascadeReweight::GetEventWeight ( const GHepRecord & event ) const{
+double CascadeReweight::GetEventWeight(const GHepRecord &event) const {
 
-  GHepParticle * p = 0;
+  GHepParticle *p = 0;
   TIter event_iter(&event);
-  double total_weight = 1. ;
-  while((p=dynamic_cast<GHepParticle *>(event_iter.Next())))
-    {  
-      // Get particle fate
-      auto fate_rescatter = p->RescatterCode() ; 
-      // Only look at particles that had FSI
-      if( fate_rescatter < 0 || fate_rescatter == kIHNFtUndefined ) continue ; 
-      INukeFateHN_t fate = (INukeFateHN_t) fate_rescatter ; 
+  double total_weight = 1.;
+  while ((p = dynamic_cast<GHepParticle *>(event_iter.Next()))) {
+    // Get particle fate
+    auto fate_rescatter = p->RescatterCode();
+    // Only look at particles that had FSI
+    if (fate_rescatter < 0 || fate_rescatter == kIHNFtUndefined)
+      continue;
+    INukeFateHN_t fate = (INukeFateHN_t)fate_rescatter;
 
-      // Read map weight:
-      const auto map_it = fFateWeightsMap.find(fate) ; 
-      // Get weight given a pdg code.
-      if( map_it != fFateWeightsMap.end() ) {
-	int pdg_target = p->Pdg() ;
-	const auto weight_it = (map_it->second).find(pdg_target) ; 
-	if( weight_it != (map_it->second).end() ) {
-	  total_weight *= weight_it->second ; 
-	  continue ; 
-	} 
-      } 
-      // If fate is not in the pdg map, use default values:
-      const auto def_it = fDefaultMap.find(fate) ; 
-      if( def_it != fDefaultMap.end() ) {
-	total_weight *= def_it->second ; 
+    // Read map weight:
+    const auto map_it = fFateWeightsMap.find(fate);
+    // Get weight given a pdg code.
+    if (map_it != fFateWeightsMap.end()) {
+      int pdg_target = p->Pdg();
+      const auto weight_it = (map_it->second).find(pdg_target);
+      if (weight_it != (map_it->second).end()) {
+        total_weight *= weight_it->second;
+        continue;
       }
-    }// end loop over particles
-  
-  return total_weight ; 
+    }
+    // If fate is not in the pdg map, use default values:
+    const auto def_it = fDefaultMap.find(fate);
+    if (def_it != fDefaultMap.end()) {
+      total_weight *= def_it->second;
+    }
+  } // end loop over particles
+
+  return total_weight;
 }
 //___________________________________________________________________________
-void CascadeReweight::Configure(const Registry & config)
-{
+void CascadeReweight::Configure(const Registry &config) {
   Algorithm::Configure(config);
   this->LoadConfig();
 }
 //___________________________________________________________________________
-void CascadeReweight::Configure(string param_set)
-{
+void CascadeReweight::Configure(string param_set) {
   Algorithm::Configure(param_set);
   this->LoadConfig();
 }
 //___________________________________________________________________________
-void CascadeReweight::LoadConfig(void)
-{
-  bool good_config = true ; 
+void CascadeReweight::LoadConfig(void) {
+  bool good_config = true;
 
   // Clean maps
-  fDefaultMap.clear(); 
+  fDefaultMap.clear();
   fFateWeightsMap.clear();
 
-  // Create vector with list of possible keys (follows the order of the fates enumeration)
-  std::map<INukeFateHN_t,string> EINukeFate_map_keys = INukeHadroFates::GetEINukeFateKeysMap() ; 
+  // Create vector with list of possible keys (follows the order of the fates
+  // enumeration)
+  std::map<INukeFateHN_t, string> EINukeFate_map_keys =
+      INukeHadroFates::GetEINukeFateKeysMap();
 
-  for ( map<INukeFateHN_t,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
+  for (map<INukeFateHN_t, string>::iterator it_keys =
+           EINukeFate_map_keys.begin();
+       it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications
-    std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
+    std::string to_find_def =
+        "CascadeReweight-Default-Weight-" + (it_keys->second);
 
-    auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;
-    for( auto kiter = kdef_list.begin(); kiter != kdef_list.end(); ++kiter ) {
-      const RgKey & key = *kiter ;
-      double weight ;
-      GetParam( key, weight ) ;
+    auto kdef_list = GetConfig().FindKeys(to_find_def.c_str());
+    for (auto kiter = kdef_list.begin(); kiter != kdef_list.end(); ++kiter) {
+      const RgKey &key = *kiter;
+      double weight;
+      GetParam(key, weight);
       // Add check weight > 0
-      if( weight < 0 ) {
-	LOG("CascadeReweight", pERROR) << "The weight assigned to " << to_find_def << " is not positive" ; 
-	good_config = false ; 
-	continue ; 
+      if (weight < 0) {
+        LOG("CascadeReweight", pERROR)
+            << "The weight assigned to " << to_find_def << " is not positive";
+        good_config = false;
+        continue;
       }
-      fDefaultMap[it_keys->first] = weight ; 
+      fDefaultMap[it_keys->first] = weight;
     }
 
     // Find Pdg specifications
-    std::string to_find_pdg = "CascadeReweight-Weight-"+(it_keys->second)+"@Pdg=" ;
-    auto kpdg_list = GetConfig().FindKeys( to_find_pdg.c_str() ) ;
-    std::map<int,double> WeightMap ; // define map that stores <pdg, weight>
-    for( auto kiter = kpdg_list.begin(); kiter != kpdg_list.end(); ++kiter ) {
-      const RgKey & key = *kiter ;
-      vector<string> kv = genie::utils::str::Split(key,"=");
-      assert(kv.size()==2);
-      int pdg_target = stoi( kv[1] );
-      if( ! PDGLibrary::Instance()->Find(pdg_target) ) {
-	LOG("CascadeReweight", pERROR) << "The target Pdg code associated to " << to_find_pdg << " is not valid : " << pdg_target ; 
-	good_config = false ; 
-	continue ; 
+    std::string to_find_pdg =
+        "CascadeReweight-Weight-" + (it_keys->second) + "@Pdg=";
+    auto kpdg_list = GetConfig().FindKeys(to_find_pdg.c_str());
+    std::map<int, double> WeightMap; // define map that stores <pdg, weight>
+    for (auto kiter = kpdg_list.begin(); kiter != kpdg_list.end(); ++kiter) {
+      const RgKey &key = *kiter;
+      vector<string> kv = genie::utils::str::Split(key, "=");
+      assert(kv.size() == 2);
+      int pdg_target = stoi(kv[1]);
+      if (!PDGLibrary::Instance()->Find(pdg_target)) {
+        LOG("CascadeReweight", pERROR)
+            << "The target Pdg code associated to " << to_find_pdg
+            << " is not valid : " << pdg_target;
+        good_config = false;
+        continue;
       }
-      double weight ;
-      GetParam( key, weight ) ;
+      double weight;
+      GetParam(key, weight);
       // Add check weight > 0
-      if( weight < 0 ) {
-	LOG("CascadeReweight", pERROR) << "The weight assigned to " << to_find_pdg << " is not positive" ; 
-	good_config = false ; 
-	continue ; 
+      if (weight < 0) {
+        LOG("CascadeReweight", pERROR)
+            << "The weight assigned to " << to_find_pdg << " is not positive";
+        good_config = false;
+        continue;
       }
       // Add pdg and weight in map
-      WeightMap.insert( std::pair<int,double>( pdg_target, weight ) ) ;
+      WeightMap.insert(std::pair<int, double>(pdg_target, weight));
     }
     // store information in class member
-    fFateWeightsMap[it_keys->first] = std::move(WeightMap) ; 
-  }  
-
-  if( ! good_config ) {
-    LOG("CascadeReweight", pFATAL) << "Configuration has failed.";
-    exit(78) ;
+    fFateWeightsMap[it_keys->first] = std::move(WeightMap);
   }
-  
+
+  if (!good_config) {
+    LOG("CascadeReweight", pFATAL) << "Configuration has failed.";
+    exit(78);
+  }
 }
 //___________________________________________________________________________

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -122,10 +122,13 @@ void CascadeReweight::LoadConfig(void)
   // Clean maps
   fMapFateWeights.clear();
   // Create vector with list of possible keys (follows the order of the fates enumeration)
-  std::vector<string> list_keys { "Undefined", "NoInteraction", "CEx", "Elastic", "Inelastic", "Abs", "Cmp" } ;
+  std::map<int,string> map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
+				  {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
+				  {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
 
-  for( unsigned int i = 0 ; i < list_keys.size() ; i++ ) { 
-    std::string to_find = "CascadeReweight-Weight-"+list_keys[i]+"@Pdg=" ;
+
+  for ( map<int,string>::iterator it_keys = map_keys.begin(); it_keys != map_keys.end(); it_keys++) {
+    std::string to_find = "CascadeReweight-Weight-"+(it_keys->second)+"@Pdg=" ;
     auto kpdg_list = GetConfig().FindKeys( to_find.c_str() ) ;
     for( auto kiter = kpdg_list.begin(); kiter != kpdg_list.end(); ++kiter ) {
       const RgKey & key = *kiter ;
@@ -141,7 +144,7 @@ void CascadeReweight::LoadConfig(void)
       GetParam( key, weight ) ;
       std::map<int,double> MapWeight ; 
       MapWeight.insert( std::pair<int,double>( pdg_target, weight ) ) ;
-      fMapFateWeights[i] = MapWeight ; 
+      fMapFateWeights[it_keys->first] = MapWeight ; 
     }
   }  
 

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -123,9 +123,7 @@ void CascadeReweight::LoadConfig(void)
   fFateWeightsMap.clear();
 
   // Create vector with list of possible keys (follows the order of the fates enumeration)
-  std::map<int,string> EINukeFate_map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
-      					     {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
-	                                     {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
+  std::map<int,string> EINukeFate_map_keys = INukeHadroFates::GetEINukeFateKeysMap() ; 
 
   for ( map<int,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -92,7 +92,7 @@ double CascadeReweight::GetEventWeight ( const GHepRecord & event ) const{
       const auto def_it = fDefaultMap.find(fate) ; 
       if( def_it != fDefaultMap.end() ) {
 	total_weight *= def_it->second ; 
-      } else total_weight *= fDefaultWeight ;
+      }
     }// end loop over particles
   
   return total_weight ; 
@@ -114,9 +114,6 @@ void CascadeReweight::LoadConfig(void)
 {
   bool good_config = true ; 
 
-  // Get default weight 
-  GetParamDef( "CascadeReweight-Default-Weight", fDefaultWeight, 1. ) ;
-  
   // Clean maps
   fDefaultMap.clear(); 
   fFateWeightsMap.clear();

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -25,7 +25,6 @@
 #include "Framework/Utils/PrintUtils.h"
 #include "Physics/NuclearState/NuclearUtils.h"
 
-#include "Physics/HadronTransport/INukeHadroFates.h" 
 #include "Framework/Utils/StringUtils.h" 
 #include "Framework/ParticleData/PDGLibrary.h"
 #include "Framework/ParticleData/PDGUtils.h"
@@ -117,22 +116,18 @@ void CascadeReweight::LoadConfig(void)
   bool good_config = true ; 
 
   // Get default weight 
-  if( GetConfig().Exists("CascadeReweight-Default-Weight") ) {
-    GetParam( "CascadeReweight-Default-Weight", fDefaultWeight ) ;
-  } else {
-    good_config = false ; 
-    LOG("CascadeReweight", pERROR) << "Default weight is not specified " ;
-  }
-
+  GetParamDef( "CascadeReweight-Default-Weight", fDefaultWeight, 1. ) ;
+  
   // Clean maps
   fDefaultMap.clear(); 
   fFateWeightsMap.clear();
-  // Create vector with list of possible keys (follows the order of the fates enumeration)
-  std::map<int,string> map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
-				  {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
-				  {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
 
-  for ( map<int,string>::iterator it_keys = map_keys.begin(); it_keys != map_keys.end(); it_keys++) {
+  // Create vector with list of possible keys (follows the order of the fates enumeration)
+  std::map<int,string> EINukeFate_map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
+      					     {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
+	                                     {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
+
+  for ( map<int,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications
     std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
     auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -1,0 +1,83 @@
+//____________________________________________________________________________
+/*
+ Copyright (c) 2003-2020, The GENIE Collaboration
+ For the full text of the license visit http://copyright.genie-mc.org
+ 
+ Julia Tena-Vidal <j.tena-vidal \at liverpool.ac.uk>
+ University of Liverpool 
+
+*/
+//____________________________________________________________________________
+
+#include <cstdlib>
+
+#include "Framework/Algorithm/AlgConfigPool.h"
+#include "Framework/Algorithm/AlgFactory.h"
+#include "Framework/Conventions/Constants.h"
+#include "Physics/HadronTransport/HadronTransporter.h"
+#include "Framework/GHEP/GHepStatus.h"
+#include "Framework/GHEP/GHepRecord.h"
+#include "Framework/GHEP/GHepParticle.h"
+#include "Framework/Interaction/Interaction.h"
+#include "Framework/Messenger/Messenger.h"
+#include "Framework/Numerical/RandomGen.h"
+#include "Framework/ParticleData/PDGUtils.h"
+#include "Framework/Utils/PrintUtils.h"
+#include "Physics/NuclearState/NuclearUtils.h"
+
+using namespace genie;
+using namespace genie::utils;
+using namespace genie::constants;
+
+//___________________________________________________________________________
+CascadeReweight::CascadeReweight() :
+EventRecordVisitorI("genie::CascadeReweight")
+{
+
+}
+//___________________________________________________________________________
+CascadeReweight::CascadeReweight(string config) :
+EventRecordVisitorI("genie::CascadeReweight", config)
+{
+
+}
+//___________________________________________________________________________
+CascadeReweight::~CascadeReweight()
+{
+
+}
+//___________________________________________________________________________
+void CascadeReweight::ProcessEventRecord(GHepRecord * evrec) const
+{
+
+}
+//___________________________________________________________________________
+void CascadeReweight::GetEventWeight (const GHepRecord & ev) const{
+
+}
+//___________________________________________________________________________
+void CascadeReweight::Configure(const Registry & config)
+{
+  Algorithm::Configure(config);
+  this->LoadConfig();
+}
+//___________________________________________________________________________
+void CascadeReweight::Configure(string param_set)
+{
+  Algorithm::Configure(param_set);
+
+  Registry * algos = AlgConfigPool::Instance() -> GlobalParameterList() ;
+  Registry r( "CascadeReweight_specific", false ) ;
+
+  Algorithm::Configure(r) ;
+
+  this->LoadConfig();
+}
+//___________________________________________________________________________
+void CascadeReweight::LoadConfig(void)
+{
+
+}
+//___________________________________________________________________________
+
+

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -70,28 +70,33 @@ double CascadeReweight::GetEventWeight ( const GHepRecord & event ) const{
 
   GHepParticle * p = 0;
   TIter event_iter(&event);
-  double total_weight = fDefaultWeight ;
+  double total_weight = 1. ;
   while((p=dynamic_cast<GHepParticle *>(event_iter.Next())))
     {  
       if( p->Status() != kIStStableFinalState ) continue;
       // Get particle fate
       int fate = event.Particle(p->FirstMother())->RescatterCode() ;
-      const auto map_it = fMapFateWeights.find(fate) ; 
+      const auto map_it = fFateWeightsMap.find(fate) ; 
 
       // Get weight given a pdg code.
-      if( map_it != fMapFateWeights.end() ) {
+      if( map_it != fFateWeightsMap.end() ) {
 	int pdg_target = p->Pdg() ;
 	const auto weight_it = (map_it->second).find(pdg_target) ; 
 	if( weight_it != (map_it->second).end() ) {
 	  total_weight *= weight_it->second ; 
-	} else { 
-	  total_weight *= fDefaultWeight ;
-	}
+	  continue ; 
+	} 
+      } 
+      // If fate is not in the pdg map, use default values:
+      const auto def_it = fDefaultMap.find(fate) ; 
+      if( def_it != fDefaultMap.end() ) {
+	total_weight *= def_it->second ; 
       } else { 
-	// Fate does not exist. Use default weight
+	// Fate not specified in xml config. Use default weight
 	total_weight *= fDefaultWeight ;
       }
     }// end loop over particles
+
   return total_weight ; 
 }
 //___________________________________________________________________________
@@ -120,32 +125,57 @@ void CascadeReweight::LoadConfig(void)
   }
 
   // Clean maps
-  fMapFateWeights.clear();
+  fDefaultMap.clear(); 
+  fFateWeightsMap.clear();
   // Create vector with list of possible keys (follows the order of the fates enumeration)
   std::map<int,string> map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
 				  {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
 				  {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
 
-
   for ( map<int,string>::iterator it_keys = map_keys.begin(); it_keys != map_keys.end(); it_keys++) {
-    std::string to_find = "CascadeReweight-Weight-"+(it_keys->second)+"@Pdg=" ;
-    auto kpdg_list = GetConfig().FindKeys( to_find.c_str() ) ;
+    // Find fate specifications
+    std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
+    auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;
+    for( auto kiter = kdef_list.begin(); kiter != kdef_list.end(); ++kiter ) {
+      const RgKey & key = *kiter ;
+      vector<string> kv = genie::utils::str::Split(key,"=");
+      assert(kv.size()==2);
+      double weight ;
+      GetParam( key, weight ) ;
+      // Add check weight > 0
+      if( weight < 0 ) {
+	LOG("CascadeReweight", pERROR) << "The weight assigned to " << to_find_def << " is not positive" ; 
+	good_config = false ; 
+	continue ; 
+      }
+      fDefaultMap[it_keys->first] = weight ; 
+    }
+
+    // Find Pdg specifications
+    std::string to_find_pdg = "CascadeReweight-Weight-"+(it_keys->second)+"@Pdg=" ;
+    auto kpdg_list = GetConfig().FindKeys( to_find_pdg.c_str() ) ;
     for( auto kiter = kpdg_list.begin(); kiter != kpdg_list.end(); ++kiter ) {
       const RgKey & key = *kiter ;
       vector<string> kv = genie::utils::str::Split(key,"=");
       assert(kv.size()==2);
       int pdg_target = stoi( kv[1] );
       if( ! PDGLibrary::Instance()->Find(pdg_target) ) {
-	LOG("CascadeReweight", pERROR) << "The target Pdg code associated to " << to_find << " is not valid : " << pdg_target ; 
+	LOG("CascadeReweight", pERROR) << "The target Pdg code associated to " << to_find_pdg << " is not valid : " << pdg_target ; 
 	good_config = false ; 
 	continue ; 
       }
       double weight ;
       GetParam( key, weight ) ;
-      std::map<int,double> MapWeight ; 
-      MapWeight.insert( std::pair<int,double>( pdg_target, weight ) ) ;
-      fMapFateWeights[it_keys->first] = MapWeight ; 
-      std::cout << " Fate : " << it_keys->first << " Weight = " << weight << " PDG = " << pdg_target << std::endl;
+      // Add check weight > 0
+      if( weight < 0 ) {
+	LOG("CascadeReweight", pERROR) << "The weight assigned to " << to_find_pdg << " is not positive" ; 
+	good_config = false ; 
+	continue ; 
+      }
+
+      std::map<int,double> WeightMap ; 
+      WeightMap.insert( std::pair<int,double>( pdg_target, weight ) ) ;
+      fFateWeightsMap[it_keys->first] = WeightMap ; 
     }
   }  
 

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -125,7 +125,6 @@ void CascadeReweight::LoadConfig(void)
   for ( map<INukeFateHN_t,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications
     std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
-    std::map<int,double> WeightMap ; // define map that stores <pdg, weight>
 
     auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;
     for( auto kiter = kdef_list.begin(); kiter != kdef_list.end(); ++kiter ) {
@@ -144,6 +143,7 @@ void CascadeReweight::LoadConfig(void)
     // Find Pdg specifications
     std::string to_find_pdg = "CascadeReweight-Weight-"+(it_keys->second)+"@Pdg=" ;
     auto kpdg_list = GetConfig().FindKeys( to_find_pdg.c_str() ) ;
+    std::map<int,double> WeightMap ; // define map that stores <pdg, weight>
     for( auto kiter = kpdg_list.begin(); kiter != kpdg_list.end(); ++kiter ) {
       const RgKey & key = *kiter ;
       vector<string> kv = genie::utils::str::Split(key,"=");
@@ -166,7 +166,7 @@ void CascadeReweight::LoadConfig(void)
       WeightMap.insert( std::pair<int,double>( pdg_target, weight ) ) ;
     }
     // store information in class member
-    fFateWeightsMap[it_keys->first] = WeightMap ; 
+    fFateWeightsMap[it_keys->first] = std::move(WeightMap) ; 
   }  
 
   if( ! good_config ) {

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -73,9 +73,10 @@ double CascadeReweight::GetEventWeight ( const GHepRecord & event ) const{
   while((p=dynamic_cast<GHepParticle *>(event_iter.Next())))
     {  
       // Get particle fate
-      INukeFateHN_t fate = (INukeFateHN_t) p->RescatterCode() ;
+      auto fate_rescatter = p->RescatterCode() ; 
       // Only look at particles that had FSI
-      if( fate < 0 ) continue ; 
+      if( fate_rescatter < 0 || fate_rescatter == kIHNFtUndefined ) continue ; 
+      INukeFateHN_t fate = (INukeFateHN_t) fate_rescatter ; 
 
       // Read map weight:
       const auto map_it = fFateWeightsMap.find(fate) ; 

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -61,6 +61,8 @@ double CascadeReweight::GetEventWeight(const GHepRecord &event) const {
   TIter event_iter(&event);
   double total_weight = 1.;
   while ((p = dynamic_cast<GHepParticle *>(event_iter.Next()))) {
+    // Look only at stable particles in the nucleus:
+    if ( p->Status() != kIStHadronInTheNucleus ) continue ; 
     // Get particle fate
     auto fate_rescatter = p->RescatterCode();
     // Only look at particles that had FSI

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -94,7 +94,7 @@ double CascadeReweight::GetEventWeight ( const GHepRecord & event ) const{
 	total_weight *= def_it->second ; 
       } else total_weight *= fDefaultWeight ;
     }// end loop over particles
-
+  
   return total_weight ; 
 }
 //___________________________________________________________________________
@@ -127,7 +127,7 @@ void CascadeReweight::LoadConfig(void)
   for ( map<INukeFateHN_t,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications
     std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
-    std::cout << " to_find_def = " << to_find_def << std::endl;
+
     auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;
     for( auto kiter = kdef_list.begin(); kiter != kdef_list.end(); ++kiter ) {
       const RgKey & key = *kiter ;

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -49,12 +49,54 @@ CascadeReweight::~CascadeReweight()
 //___________________________________________________________________________
 void CascadeReweight::ProcessEventRecord(GHepRecord * evrec) const
 {
+  // Get Associated weight
+  // Set weight 
 
 }
 //___________________________________________________________________________
 void CascadeReweight::GetEventWeight (const GHepRecord & ev) const{
+  // Get faith
+  // Return weight given the faith
+  // List of faiths
 
+  /*
+  //__________________________________________________________________________
+  static string AsString(INukeFateHN_t fate) {
+     switch (fate) {
+      case kIHNFtUndefined : return "** Undefined HN-mode fate **"; break;
+      case kIHNFtCEx       : return "HN-mode / cex";    break;
+      case kIHNFtElas      : return "HN-mode / elas";   break;
+      case kIHNFtInelas    : return "HN-mode / inelas"; break;
+      case kIHNFtAbs       : return "HN-mode / abs";    break;
+      case kIHNFtCmp   : return "HN-mode / compound"; break;
+      case kIHNFtNoInteraction : return "HN-mode / no interaction"; break;
+      default              : break; 
+     }
+     return "** Undefined HN-mode fate **"; 
+  }
+  //__________________________________________________________________________
+  static string AsString(INukeFateHA_t fate) {
+     switch (fate) {
+      case kIHAFtUndefined : return "** Undefined HA-mode fate **"; break;
+      case kIHAFtNoInteraction : return "HA-mode / no interaction"; break;
+      case kIHAFtCEx       : return "HA-mode / cex";            break;
+      //      case kIHAFtElas      : return "HA-mode / elas";           break;
+      case kIHAFtInelas    : return "HA-mode / inelas";         break;
+      case kIHAFtAbs       : return "HA-mode / abs";            break;
+      case kIHAFtKo        : return "HA-mode / knock-out";      break;
+      case kIHAFtCmp       : return "HA-mode / compound";       break;
+      case kIHAFtPiProd    : return "HA-mode / pi-production" ; break;
+      case kIHAFtInclPip   : return "HA-mode / pi-prod incl pi+";   break;
+      case kIHAFtInclPim   : return "HA-mode / pi-prod incl pi-";   break;
+      case kIHAFtInclPi0   : return "HA-mode / pi-prod incl pi0";   break;
+      case kIHAFtDCEx      : return "HA-mode / dcex";           break;
+      default              : break;
+     }
+     return "** Undefined HA-mode fate **"; 
+  }
+   */
 }
+
 //___________________________________________________________________________
 void CascadeReweight::Configure(const Registry & config)
 {
@@ -76,6 +118,9 @@ void CascadeReweight::Configure(string param_set)
 //___________________________________________________________________________
 void CascadeReweight::LoadConfig(void)
 {
+
+  // Read xml configuration
+  // Here we need to store the scaling factors associated to each weight
 
 }
 //___________________________________________________________________________

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -125,6 +125,7 @@ void CascadeReweight::LoadConfig(void)
   for ( map<INukeFateHN_t,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications
     std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
+    std::map<int,double> WeightMap ; // define map that stores <pdg, weight>
 
     auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;
     for( auto kiter = kdef_list.begin(); kiter != kdef_list.end(); ++kiter ) {
@@ -142,7 +143,6 @@ void CascadeReweight::LoadConfig(void)
 
     // Find Pdg specifications
     std::string to_find_pdg = "CascadeReweight-Weight-"+(it_keys->second)+"@Pdg=" ;
-    std::map<int,double> WeightMap ; // define map that stores <pdg, weight>
     auto kpdg_list = GetConfig().FindKeys( to_find_pdg.c_str() ) ;
     for( auto kiter = kpdg_list.begin(); kiter != kpdg_list.end(); ++kiter ) {
       const RgKey & key = *kiter ;
@@ -170,7 +170,7 @@ void CascadeReweight::LoadConfig(void)
   }  
 
   if( ! good_config ) {
-    LOG("CascadeReweight", pERROR) << "Configuration has failed.";
+    LOG("CascadeReweight", pFATAL) << "Configuration has failed.";
     exit(78) ;
   }
   

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -74,7 +74,7 @@ double CascadeReweight::GetEventWeight ( const GHepRecord & event ) const{
     {  
       if( p->Status() != kIStStableFinalState ) continue;
       // Get particle fate
-      int fate = event.Particle(p->FirstMother())->RescatterCode() ;
+      INukeFateHN_t fate = (INukeFateHN_t) event.Particle(p->FirstMother())->RescatterCode() ;
       const auto map_it = fFateWeightsMap.find(fate) ; 
 
       // Get weight given a pdg code.
@@ -123,9 +123,9 @@ void CascadeReweight::LoadConfig(void)
   fFateWeightsMap.clear();
 
   // Create vector with list of possible keys (follows the order of the fates enumeration)
-  std::map<int,string> EINukeFate_map_keys = INukeHadroFates::GetEINukeFateKeysMap() ; 
+  std::map<INukeFateHN_t,string> EINukeFate_map_keys = INukeHadroFates::GetEINukeFateKeysMap() ; 
 
-  for ( map<int,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
+  for ( map<INukeFateHN_t,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications
     std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
     auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -145,6 +145,7 @@ void CascadeReweight::LoadConfig(void)
       std::map<int,double> MapWeight ; 
       MapWeight.insert( std::pair<int,double>( pdg_target, weight ) ) ;
       fMapFateWeights[it_keys->first] = MapWeight ; 
+      std::cout << " Fate : " << it_keys->first << " Weight = " << weight << " PDG = " << pdg_target << std::endl;
     }
   }  
 

--- a/src/Physics/HadronTransport/CascadeReweight.cxx
+++ b/src/Physics/HadronTransport/CascadeReweight.cxx
@@ -127,11 +127,10 @@ void CascadeReweight::LoadConfig(void)
   for ( map<INukeFateHN_t,string>::iterator it_keys = EINukeFate_map_keys.begin(); it_keys != EINukeFate_map_keys.end(); it_keys++) {
     // Find fate specifications
     std::string to_find_def = "CascadeReweight-Default-Weight-"+(it_keys->second) ;
+    std::cout << " to_find_def = " << to_find_def << std::endl;
     auto kdef_list = GetConfig().FindKeys( to_find_def.c_str() ) ;
     for( auto kiter = kdef_list.begin(); kiter != kdef_list.end(); ++kiter ) {
       const RgKey & key = *kiter ;
-      vector<string> kv = genie::utils::str::Split(key,"=");
-      assert(kv.size()==2);
       double weight ;
       GetParam( key, weight ) ;
       // Add check weight > 0

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -5,9 +5,9 @@
 
 \brief    In this module, the event weight is set depending on the FSI fate. 
           The weights are set depending on the xml configuration defined by the user
-\author    Julia Tena-Vidal <j.tena-vidal \at liverpool.ac.uk>
+\author   Julia Tena-Vidal <j.tena-vidal \at liverpool.ac.uk>
 
-\created  July 2020
+\created  July 2021
 
 \cpright  Copyright (c) 2003-2020, The GENIE Collaboration
           For the full text of the license visit http://copyright.genie-mc.org
@@ -44,7 +44,6 @@ private:
   void LoadConfig     (void); ///< read configuration from xml file
 
   // Class member
-  double fDefaultWeight ; 
   std::map< INukeFateHN_t, double > fDefaultMap ; // fate, weight 
   std::map< INukeFateHN_t, map<int,double> > fFateWeightsMap ; // < fate, <pdg,weight> > 
 

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -43,6 +43,11 @@ public :
 private:
   void LoadConfig     (void); ///< read configuration from xml file
 
+  static const std::map<INukeFateHN_t,string> & GetEINukeFateKeysMap( void ) {
+    static const std::map<INukeFateHN_t,string> map_keys { {kIHNFtNoInteraction,"NoInteraction"},{kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},{kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
+    return map_keys ; 
+  }
+
   // Class member
   std::map< INukeFateHN_t, double > fDefaultMap ; // fate, weight 
   std::map< INukeFateHN_t, map<int,double> > fFateWeightsMap ; // < fate, <pdg,weight> > 

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -44,7 +44,8 @@ private:
 
   // Class member
   double fDefaultWeight ; 
-  std::map< int , map<int,double> > fMapFateWeights ;
+  std::map< int , double > fDefaultMap ; // fate, weight 
+  std::map< int , map<int,double> > fFateWeightsMap ; // < fate, <pdg,weight> > 
 
 };
 

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -19,7 +19,7 @@
 #define _CASCADE_REWEIGHT_H_
 
 #include "Framework/EventGen/EventRecordVisitorI.h"
-#include "Physics/HadronTransport/INukeHadroFates.h" 
+#include "Physics/HadronTransport/INukeHadroFates2018.h" 
 
 namespace genie {
 

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -19,6 +19,7 @@
 #define _CASCADE_REWEIGHT_H_
 
 #include "Framework/EventGen/EventRecordVisitorI.h"
+#include "Physics/HadronTransport/INukeHadroFates.h" 
 
 namespace genie {
 

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -36,10 +36,15 @@ public :
   // data to private data members
   void Configure (const Registry & config);
   void Configure (string param_set);
+ protected:
+  double GetEventWeight (const GHepRecord & ev) const; ///< get weight from fate and configuration
 
 private:
   void LoadConfig     (void); ///< read configuration from xml file
-  void GetEventWeight (const GHepRecord & ev) const; ///< get weight from fate and configuration
+
+  // Class member
+  double fDefaultWeight ; 
+  std::map< int , map<int,double> > fMapFateWeights ;
 
 };
 

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -45,8 +45,8 @@ private:
 
   // Class member
   double fDefaultWeight ; 
-  std::map< int , double > fDefaultMap ; // fate, weight 
-  std::map< int , map<int,double> > fFateWeightsMap ; // < fate, <pdg,weight> > 
+  std::map< INukeFateHN_t, double > fDefaultMap ; // fate, weight 
+  std::map< INukeFateHN_t, map<int,double> > fFateWeightsMap ; // < fate, <pdg,weight> > 
 
 };
 

--- a/src/Physics/HadronTransport/CascadeReweight.h
+++ b/src/Physics/HadronTransport/CascadeReweight.h
@@ -1,0 +1,47 @@
+//____________________________________________________________________________
+/*!
+
+\class    genie::CascadeReweight
+
+\brief    In this module, the event weight is set depending on the FSI fate. 
+          The weights are set depending on the xml configuration defined by the user
+\author    Julia Tena-Vidal <j.tena-vidal \at liverpool.ac.uk>
+
+\created  July 2020
+
+\cpright  Copyright (c) 2003-2020, The GENIE Collaboration
+          For the full text of the license visit http://copyright.genie-mc.org
+          
+*/
+//____________________________________________________________________________
+
+#ifndef _CASCADE_REWEIGHT_H_
+#define _CASCADE_REWEIGHT_H_
+
+#include "Framework/EventGen/EventRecordVisitorI.h"
+
+namespace genie {
+
+class CascadeReweight : public EventRecordVisitorI {
+
+public :
+  CascadeReweight();
+  CascadeReweight(string config);
+ ~CascadeReweight();
+
+  // implement the EventRecordVisitorI interface
+  void ProcessEventRecord(GHepRecord * event_rec) const;
+
+  // override the Algorithm::Configure methods to load configuration
+  // data to private data members
+  void Configure (const Registry & config);
+  void Configure (string param_set);
+
+private:
+  void LoadConfig     (void); ///< read configuration from xml file
+  void GetEventWeight (const GHepRecord & ev) const; ///< get weight from fate and configuration
+
+};
+
+}      // genie namespace
+#endif // _CASCADE_REWEIGHT_H_

--- a/src/Physics/HadronTransport/HadronTransporter.cxx
+++ b/src/Physics/HadronTransport/HadronTransporter.cxx
@@ -139,6 +139,7 @@ void HadronTransporter::Configure(string param_set)
 
   r.Set("HadronTransp-Enable", algos -> GetBool("HadronTransp-Enable") ) ;
   r.Set("HadronTransp-Model",  algos -> GetAlg("HadronTransp-Model")   ) ;
+  r.Set("CascadeReweightAlg",  algos -> GetAlg("CascadeReweightAlg")   ) ;
 
   Algorithm::Configure(r) ;
 

--- a/src/Physics/HadronTransport/HadronTransporter.cxx
+++ b/src/Physics/HadronTransport/HadronTransporter.cxx
@@ -24,6 +24,7 @@
 #include "Framework/Algorithm/AlgFactory.h"
 #include "Framework/Conventions/Constants.h"
 #include "Physics/HadronTransport/HadronTransporter.h"
+#include "Physics/HadronTransport/CascadeReweight.h"
 #include "Framework/GHEP/GHepStatus.h"
 #include "Framework/GHEP/GHepRecord.h"
 #include "Framework/GHEP/GHepParticle.h"
@@ -79,6 +80,11 @@ void HadronTransporter::ProcessEventRecord(GHepRecord * evrec) const
   // Use the specified intrsnuclear rescattering model
   LOG("HadTransp", pINFO)  << "Calling the selected hadron transport MC";
   fHadTranspModel->ProcessEventRecord(evrec);
+
+  // Process Event record for the cascade reweight if required:
+  if(fCascadeReweight) fCascadeReweight->ProcessEventRecord(evrec);
+
+  return ;
 }
 //___________________________________________________________________________
 void HadronTransporter::TransportInTransparentNuc(GHepRecord * evrec) const
@@ -141,6 +147,8 @@ void HadronTransporter::Configure(string param_set)
 //___________________________________________________________________________
 void HadronTransporter::LoadConfig(void)
 {
+  bool good_config = true ;
+
   fHadTranspModel = 0;
   GetParam("HadronTransp-Enable", fEnabled ) ;
 
@@ -154,7 +162,26 @@ void HadronTransporter::LoadConfig(void)
 
      fHadTranspModel = 
          dynamic_cast<const EventRecordVisitorI *> ( this -> SubAlg("HadronTransp-Model") );
-     assert(fHadTranspModel);
+
+     if(!fHadTranspModel){
+       good_config = false ;
+       LOG("HadronTransporter", pERROR) << "The SubAlg HadronTransp-Model is not a XSecAlgorithmI";
+     }
+
+     // Read optional CascadeReweight EventRecordVisitorI
+     fCascadeReweight = nullptr; 
+     if( GetConfig().Exists("CascadeReweightAlg") ) {
+       fCascadeReweight = dynamic_cast<const CascadeReweight *> ( this->SubAlg("CascadeReweightAlg") );
+       if( !fCascadeReweight ) {
+	 good_config = false ; 
+	 LOG("HadronTransporter", pERROR) << "The required CascadeReweightAlg does not exist. AlgID is : " << SubAlg("CascadeReweightAlg")->Id() ;
+       }
+     }
+
+     if( ! good_config ) {
+       LOG("HadronTransporter", pERROR) << "Configuration has failed.";
+       exit(78) ;
+     }
   }
 }
 //___________________________________________________________________________

--- a/src/Physics/HadronTransport/HadronTransporter.cxx
+++ b/src/Physics/HadronTransport/HadronTransporter.cxx
@@ -139,9 +139,9 @@ void HadronTransporter::Configure(string param_set)
 
   r.Set("HadronTransp-Enable", algos -> GetBool("HadronTransp-Enable") ) ;
   r.Set("HadronTransp-Model",  algos -> GetAlg("HadronTransp-Model")   ) ;
-  //  if( r.Exists("CascadeReweightAlg") ) {
+  if( algos->Exists("CascadeReweightAlg") ) {
     r.Set("CascadeReweightAlg",  algos -> GetAlg("CascadeReweightAlg")   ) ;
-    //}
+  }
 
   Algorithm::Configure(r) ;
 

--- a/src/Physics/HadronTransport/HadronTransporter.cxx
+++ b/src/Physics/HadronTransport/HadronTransporter.cxx
@@ -139,9 +139,9 @@ void HadronTransporter::Configure(string param_set)
 
   r.Set("HadronTransp-Enable", algos -> GetBool("HadronTransp-Enable") ) ;
   r.Set("HadronTransp-Model",  algos -> GetAlg("HadronTransp-Model")   ) ;
-  if( r.Exists("CascadeReweightAlg") ) {
+  //  if( r.Exists("CascadeReweightAlg") ) {
     r.Set("CascadeReweightAlg",  algos -> GetAlg("CascadeReweightAlg")   ) ;
-  }
+    //}
 
   Algorithm::Configure(r) ;
 

--- a/src/Physics/HadronTransport/HadronTransporter.cxx
+++ b/src/Physics/HadronTransport/HadronTransporter.cxx
@@ -139,7 +139,9 @@ void HadronTransporter::Configure(string param_set)
 
   r.Set("HadronTransp-Enable", algos -> GetBool("HadronTransp-Enable") ) ;
   r.Set("HadronTransp-Model",  algos -> GetAlg("HadronTransp-Model")   ) ;
-  r.Set("CascadeReweightAlg",  algos -> GetAlg("CascadeReweightAlg")   ) ;
+  if( r.Exists("CascadeReweightAlg") ) {
+    r.Set("CascadeReweightAlg",  algos -> GetAlg("CascadeReweightAlg")   ) ;
+  }
 
   Algorithm::Configure(r) ;
 

--- a/src/Physics/HadronTransport/HadronTransporter.h
+++ b/src/Physics/HadronTransport/HadronTransporter.h
@@ -46,6 +46,7 @@ private:
 
   bool  fEnabled;                              ///< hadron transport enabled?
   const EventRecordVisitorI * fHadTranspModel; ///< hadron transport MC to use
+  const EventRecordVisitorI * fCascadeReweight; ///< Cascade reweight member
 
 };
 

--- a/src/Physics/HadronTransport/INukeHadroFates.h
+++ b/src/Physics/HadronTransport/INukeHadroFates.h
@@ -23,8 +23,6 @@
 
 #include <string>
 
-
-
 namespace genie {
 
 using std::string;
@@ -118,6 +116,7 @@ public:
      return "undefined"; 
   }
   //__________________________________________________________________________
+
 };
 
 }      // genie

--- a/src/Physics/HadronTransport/INukeHadroFates2018.h
+++ b/src/Physics/HadronTransport/INukeHadroFates2018.h
@@ -116,6 +116,15 @@ public:
      return "undefined"; 
   }
   //__________________________________________________________________________
+
+  static std::map<int,string> GetEINukeFateKeysMap( void ) {
+    static std::map<int,string> map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
+      				           {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
+	                                   {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
+    return map_keys ; 
+  }
+  //__________________________________________________________________________
+
 };
 
 }      // genie

--- a/src/Physics/HadronTransport/INukeHadroFates2018.h
+++ b/src/Physics/HadronTransport/INukeHadroFates2018.h
@@ -117,14 +117,6 @@ public:
   }
   //__________________________________________________________________________
 
-  static std::map<INukeFateHN_t,string> GetEINukeFateKeysMap( void ) {
-    static std::map<INukeFateHN_t,string> map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
-      				           {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
-	                                   {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
-    return map_keys ; 
-  }
-  //__________________________________________________________________________
-
 };
 
 }      // genie

--- a/src/Physics/HadronTransport/INukeHadroFates2018.h
+++ b/src/Physics/HadronTransport/INukeHadroFates2018.h
@@ -117,8 +117,8 @@ public:
   }
   //__________________________________________________________________________
 
-  static std::map<int,string> GetEINukeFateKeysMap( void ) {
-    static std::map<int,string> map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
+  static std::map<INukeFateHN_t,string> GetEINukeFateKeysMap( void ) {
+    static std::map<INukeFateHN_t,string> map_keys { {kIHNFtUndefined,"Undefined"}, {kIHNFtNoInteraction,"NoInteraction"}, 
       				           {kIHNFtCEx,"CEx"}, {kIHNFtElas,"Elastic"}, {kIHNFtInelas,"Inelastic"},
 	                                   {kIHNFtAbs,"Abs"}, {kIHNFtCmp,"Cmp"} } ;
     return map_keys ; 

--- a/src/Physics/HadronTransport/LinkDef.h
+++ b/src/Physics/HadronTransport/LinkDef.h
@@ -22,6 +22,8 @@
 #pragma link C++ class genie::HAIntranuke2018;
 #pragma link C++ class genie::HNIntranuke2018;
 
+#pragma link C++ class genie::CascadeReweight;
+
 #ifdef __GENIE_INCL_ENABLED__
 #pragma link C++ class genie::HINCLCascadeIntranuke;
 #endif


### PR DESCRIPTION
This class loops over the event record to find particles that were affected by FSI. Depending on their fate, we apply a weight to the event. This option can be configured using the corresponding xml files. The code is generic given that the HadronTransporter model sets the HN Fates. 