### PR TITLE
Fixing default behaviour

### DIFF
--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
@@ -54,7 +54,7 @@ double MECScaleVsW::GetScaling( const double Q0, const double Q3 ) const
   // Do not scale if W<0. This can happen while we try to get the correct kinematics.
   // If the kinematics is not correct, W can be negative, and we scale with a nan.
   // To avoid this we do this check.
-  if ( W < 0 ) return fDefaultWeight ; 
+  if ( W < 0 ) return 1. ; 
   W = sqrt( W ) ; 
 
   // Calculate scaling:


### PR DESCRIPTION
The weight for events with W<0 is left to the default weight of 1. Because the default weight is configurable (fDefaultWeight), I decided to change this to 1 to avoid confusion. 