### PR TITLE
Update SlowRsclCharmDISPXSecLO.h

### DIFF
--- a/src/Physics/Charm/XSection/SlowRsclCharmDISPXSecLO.h
+++ b/src/Physics/Charm/XSection/SlowRsclCharmDISPXSecLO.h
@@ -25,7 +25,7 @@
 namespace genie {
 
 class PDFModelI;
-class XSecIntegrator;
+class XSecIntegratorI;
 
 class SlowRsclCharmDISPXSecLO : public XSecAlgorithmI {
 


### PR DESCRIPTION
fix typo in forward declaration of XSecIntegratorI (was missing trailing "I").  Caused difficulties in dictionary creation if headers in directory were used in reverse alphabetical order.