### PR TITLE
adding different parameters for neutral and charged pion mean free path

### DIFF
--- a/config/HAIntranuke2018.xml
+++ b/config/HAIntranuke2018.xml
@@ -57,7 +57,8 @@ DelRNucleon         double  Yes   mult. factor for nucleon de-Broglie wavelength
     <!-- Note that now all these parameters are not mandatory and their default is 1
          they are reported just to inform the user what can be tweaked -->
     <!--
-    <param type="double" name="FSI-Pion-MFPScale">            1.000 </param>
+    <param type="double" name="FSI-ChargedPion-MFPScale">     1.000 </param>
+    <param type="double" name="FSI-NeutralPion-MFPScale">     1.000 </param>
     <param type="double" name="FSI-Pion-FracCExScale">        1.000 </param>
     <param type="double" name="FSI-Pion-FracInelScale">       1.000 </param>
     <param type="double" name="FSI-ChargedPion-FracAbsScale"> 1.000 </param>

--- a/src/Physics/HadronTransport/HAIntranuke.cxx
+++ b/src/Physics/HadronTransport/HAIntranuke.cxx
@@ -1408,7 +1408,8 @@ void HAIntranuke::LoadConfig(void)
   GetParam( "HAINUKE-DelRPion",    fDelRPion ) ;
   GetParam( "HAINUKE-DelRNucleon", fDelRNucleon ) ;
 
-  GetParamDef( "FSI-Pion-MFPScale",              fPionMFPScale,           1.0 ) ;
+  GetParamDef( "FSI-ChargedPion-MFPScale",       fChPionMFPScale,         1.0 ) ;
+  GetParamDef( "FSI-NeutralPion-MFPScale",       fNeutralPionMFPScale,    1.0 ) ;
   GetParamDef( "FSI-Pion-FracCExScale",          fPionFracCExScale,       1.0 ) ;
   GetParamDef( "FSI-Pion-FracAbsScale",          fPionFracAbsScale,       1.0 ) ;
   GetParamDef( "FSI-Pion-FracElasScale",         fPionFracElasScale,      1.0 ) ;

--- a/src/Physics/HadronTransport/HAIntranuke2018.cxx
+++ b/src/Physics/HadronTransport/HAIntranuke2018.cxx
@@ -1548,7 +1548,8 @@ void HAIntranuke2018::LoadConfig(void)
   GetParam( "HAINUKE-DelRPion",    fDelRPion ) ;
   GetParam( "HAINUKE-DelRNucleon", fDelRNucleon ) ;
 
-  GetParamDef( "FSI-Pion-MFPScale",              fPionMFPScale,           1.0 ) ;
+  GetParamDef( "FSI-ChargedPion-MFPScale",       fChPionMFPScale,         1.0 ) ;
+  GetParamDef( "FSI-NeutralPion-MFPScale",       fNeutralPionMFPScale,    1.0 ) ;
   GetParamDef( "FSI-Pion-FracCExScale",          fPionFracCExScale,       1.0 ) ;
   GetParamDef( "FSI-ChargedPion-FracAbsScale",   fChPionFracAbsScale,     1.0 ) ;
   GetParamDef( "FSI-NeutralPion-FracAbsScale",   fNeutralPionFracAbsScale,1.0 ) ;

--- a/src/Physics/HadronTransport/HNIntranuke2018.cxx
+++ b/src/Physics/HadronTransport/HNIntranuke2018.cxx
@@ -979,7 +979,8 @@ void HNIntranuke2018::LoadConfig(void)
   GetParam( "HNINUKE-DelRPion",    fDelRPion ) ;
   GetParam( "HNINUKE-DelRNucleon", fDelRNucleon ) ;
 
-  GetParamDef( "FSI-Pion-MFPScale",              fPionMFPScale,           1.0 ) ;
+  GetParamDef( "FSI-ChargedPion-MFPScale",       fChPionMFPScale,         1.0 ) ;
+  GetParamDef( "FSI-NeutralPion-MFPScale",       fNeutralPionMFPScale,    1.0 ) ;
   GetParamDef( "FSI-Nucleon-MFPScale",           fNucleonMFPScale,        1.0 ) ;
 
   // report
@@ -1000,7 +1001,8 @@ void HNIntranuke2018::LoadConfig(void)
   LOG("HNIntranuke2018", pWARN) << "useOset     = " << fUseOset;
   LOG("HNIntranuke2018", pWARN) << "altOset     = " << fAltOset;
   LOG("HNIntranuke2018", pWARN) << "XsecNNCorr? = " << ((fXsecNNCorr)?(true):(false));
-  LOG("HNIntranuke2018", pWARN) << "FSI-Pion-MFPScale     = " << fPionMFPScale;
+  LOG("HNIntranuke2018", pWARN) << "FSI-ChargedPion-MFPScale     = " << fChPionMFPScale;
+  LOG("HNIntranuke2018", pWARN) << "FSI-NeutralPion-MFPScale     = " << fNeutralPionMFPScale;
 }
 //___________________________________________________________________________
 

--- a/src/Physics/HadronTransport/Intranuke.cxx
+++ b/src/Physics/HadronTransport/Intranuke.cxx
@@ -401,8 +401,11 @@ double Intranuke::GenerateStep(GHepRecord* /*evrec*/, GHepParticle* p) const
   int pdgc = p->Pdg();
 
   double scale = 1.;
-  if (pdgc==kPdgPiP || pdgc==kPdgPiM || pdgc==kPdgPi0) {
-    scale = fPionMFPScale; 
+  if (pdgc==kPdgPiP || pdgc==kPdgPiM) {
+    scale = fChPionMFPScale; 
+  }
+  if (pdgc==kPdgPi0) {
+    scale = fNeutralPionMFPScale; 
   }
   else if (pdgc==kPdgProton || pdgc==kPdgNeutron) {
     scale = fNucleonMFPScale;

--- a/src/Physics/HadronTransport/Intranuke.h
+++ b/src/Physics/HadronTransport/Intranuke.h
@@ -114,7 +114,8 @@ protected:
   bool         fDoMassDiff;   ///< whether or not to do mass diff. mode
   bool         fDoCompoundNucleus; ///< whether or not to do compound nucleus considerations
 
-  double       fPionMFPScale;       ///< tweaking factors for tuning
+  double       fChPionMFPScale;       ///< tweaking factors for tuning
+  double       fNeutralPionMFPScale;
   double       fPionFracCExScale;
   double       fPionFracElasScale;
   double       fPionFracInelScale;

--- a/src/Physics/HadronTransport/Intranuke2018.cxx
+++ b/src/Physics/HadronTransport/Intranuke2018.cxx
@@ -402,8 +402,11 @@ double Intranuke2018::GenerateStep(GHepRecord*  /*evrec*/, GHepParticle* p) cons
   int pdgc = p->Pdg();
 
   double scale = 1.;
-  if (pdgc==kPdgPiP || pdgc==kPdgPiM || pdgc==kPdgPi0) {
-    scale = fPionMFPScale;
+  if (pdgc==kPdgPiP || pdgc==kPdgPiM) {
+    scale = fChPionMFPScale;
+  }
+  if (pdgc==kPdgPi0) {
+    scale = fNeutralPionMFPScale;
   }
   else if (pdgc==kPdgProton || pdgc==kPdgNeutron) {
     scale = fNucleonMFPScale;

--- a/src/Physics/HadronTransport/Intranuke2018.h
+++ b/src/Physics/HadronTransport/Intranuke2018.h
@@ -120,7 +120,8 @@ protected:
   bool         fAltOset;      ///< NuWro's table-based implementation (not recommended)
   bool         fXsecNNCorr;   ///< use nuclear medium correction for NN cross section
 
-  double       fPionMFPScale;       ///< tweaking factors for tuning
+  double       fChPionMFPScale;       ///< tweaking factors for tuning
+  double       fNeutralPionMFPScale;
   double       fPionFracCExScale;
   double       fPionFracInelScale;
   double       fChPionFracAbsScale;


### PR DESCRIPTION
Adding a MFP parameter for Charged and Neutral pions. This adds coherence between the Frac Abs charged pions parameter and the MFP.