### PR TITLE
Add forward declarations and using statements so that header order in dictionary creation doesn't matter

### DIFF
--- a/src/Framework/EventGen/EventGeneratorListAssembler.h
+++ b/src/Framework/EventGen/EventGeneratorListAssembler.h
@@ -20,6 +20,8 @@
 #define _EVENT_GENERATOR_LIST_ASSEMBLER_H_
 
 #include "Framework/Algorithm/Algorithm.h"
+#include <string>
+using std::string;
 
 namespace genie {
 

--- a/src/Framework/EventGen/GMCJMonitor.h
+++ b/src/Framework/EventGen/GMCJMonitor.h
@@ -21,6 +21,8 @@
 #define _G_MC_JOB_MONITOR_H_
 
 #include <TStopwatch.h>
+#include <string>
+using std::string;
 
 namespace genie {
 

--- a/src/Framework/Interaction/Interaction.h
+++ b/src/Framework/Interaction/Interaction.h
@@ -38,6 +38,7 @@
 
 using std::ostream;
 using std::string;
+using std::pair;
 
 class TRootIOCtor;
 

--- a/src/Framework/Numerical/GSLUtils.h
+++ b/src/Framework/Numerical/GSLUtils.h
@@ -19,6 +19,8 @@
 #define _GSL_UTILS_H_
 
 #include <Math/AllIntegrationTypes.h>
+#include <string>
+using std::string;
 
 namespace genie {
 namespace utils {

--- a/src/Framework/Utils/AppInit.h
+++ b/src/Framework/Utils/AppInit.h
@@ -20,6 +20,9 @@
 #ifndef _APP_INIT_UTILS_H_
 #define _APP_INIT_UTILS_H_
 
+#include <string>
+using std::string;
+
 namespace genie {
 namespace utils {
 

--- a/src/Framework/Utils/UnitUtils.h
+++ b/src/Framework/Utils/UnitUtils.h
@@ -18,6 +18,9 @@
 #ifndef _UNIT_UTILS_H_
 #define _UNIT_UTILS_H_
 
+#include <string>
+using std::string;
+
 namespace genie {
 namespace utils {
 

--- a/src/Physics/HadronTransport/HG4BertCascIntranuke.h
+++ b/src/Physics/HadronTransport/HG4BertCascIntranuke.h
@@ -30,6 +30,9 @@
 #include <TLorentzVector.h>
 class TVector3;
 
+#include <string>
+using std::string;
+
 class G4ParticleDefinition;
 class G4KineticTrackVector;
 

--- a/src/Physics/HadronTransport/HINCLCascadeIntranuke.h
+++ b/src/Physics/HadronTransport/HINCLCascadeIntranuke.h
@@ -5,6 +5,7 @@
 #define _HINCLCascadeIntranuke_H_
 
 #include <string>
+using std::string;
 
 #include "Framework/EventGen/EventRecordVisitorI.h"
 #include "Framework/Conventions/GMode.h"

--- a/src/Physics/PartonDistributions/LHAPDF5.h
+++ b/src/Physics/PartonDistributions/LHAPDF5.h
@@ -20,6 +20,8 @@
 #define _LHAPDF5_H_
 
 #include "Physics/PartonDistributions/PDFModelI.h"
+#include <string>
+using std::string;
 
 namespace genie {
 

--- a/src/Physics/PartonDistributions/LHAPDF6.h
+++ b/src/Physics/PartonDistributions/LHAPDF6.h
@@ -21,6 +21,8 @@
 
 #include "Framework/Conventions/GBuild.h"
 #include "Physics/PartonDistributions/PDFModelI.h"
+#include <string>
+using std::string;
 
 namespace LHAPDF
 {

--- a/src/Physics/Resonance/XSection/BostedChristyEMPXSec.h
+++ b/src/Physics/Resonance/XSection/BostedChristyEMPXSec.h
@@ -34,6 +34,8 @@
 #include "Framework/EventGen/XSecAlgorithmI.h"
 #include "Physics/NuclearState/FermiMomentumTable.h"
 
+class XSecIntegratorI;
+
 namespace genie {
 
 class BostedChristyEMPXSec : public XSecAlgorithmI {

--- a/src/Physics/XSectionIntegration/GSLXSecFunc.h
+++ b/src/Physics/XSectionIntegration/GSLXSecFunc.h
@@ -22,6 +22,9 @@
 #include <Math/IntegratorMultiDim.h>
 #include "Framework/Utils/Range1.h"
 
+#include <string>
+using std::string;
+
 namespace genie {
 
 class XSecAlgorithmI;


### PR DESCRIPTION
Future versions of ROOT dictionary code will no longer include the line `namespace std {} using namespace std;`
Additionally the header order from a glob might be different