### PR TITLE
adding Qvalue shift on q0Tilde

### DIFF
--- a/src/Physics/QuasiElastic/XSection/NievesQELCCPXSec.cxx
+++ b/src/Physics/QuasiElastic/XSection/NievesQELCCPXSec.cxx
@@ -204,6 +204,9 @@ double NievesQELCCPXSec::XSec(const Interaction * interaction,
 
   double q0Tilde = outNucleonMom.E() - inNucleonMomOnShell.E();
 
+  // Shift the q0Tilde if required:
+  if( fQvalueShifter ) q0Tilde += q0Tilde * fQvalueShifter->Shift(*interaction) ;
+
   // If binding energy effects pull us into an unphysical region, return
   // zero for the differential cross section
   if ( q0Tilde <= 0. && target.IsNucleus() && !interaction->TestBit(kIAssumeFreeNucleon) ) return 0.;
@@ -390,6 +393,7 @@ void NievesQELCCPXSec::Configure(string config)
 //____________________________________________________________________________
 void NievesQELCCPXSec::LoadConfig(void)
 {
+  bool good_config = true ; 
   double thc;
   GetParam( "CabibboAngle", thc ) ;
   fCos8c2 = TMath::Power(TMath::Cos(thc), 2);
@@ -485,6 +489,22 @@ void NievesQELCCPXSec::LoadConfig(void)
 
   // Decide whether or not it should be used in XSec()
   GetParamDef( "DoPauliBlocking", fDoPauliBlocking, true );
+
+  // Read optional QvalueShifter:
+  fQvalueShifter = nullptr; 
+  if( GetConfig().Exists("QvalueShifterAlg") ) {
+    fQvalueShifter = dynamic_cast<const QvalueShifter *> ( this->SubAlg("QvalueShifterAlg") );
+    if( !fQvalueShifter ) {
+      good_config = false ; 
+      LOG("NievesQELCCPXSec", pERROR) << "The required QvalueShifterAlg does not exist. AlgID is : " << SubAlg("QvalueShifterAlg")->Id() ;
+    }
+  }
+
+  if( ! good_config ) {
+    LOG("NievesQELCCPXSec", pERROR) << "Configuration has failed.";
+    exit(78) ;
+  }
+
 }
 //___________________________________________________________________________
 void NievesQELCCPXSec::CNCTCLimUcalc(TLorentzVector qTildeP4,

--- a/src/Physics/QuasiElastic/XSection/NievesQELCCPXSec.h
+++ b/src/Physics/QuasiElastic/XSection/NievesQELCCPXSec.h
@@ -30,6 +30,7 @@
 #include "Physics/NuclearState/NuclearModelI.h"
 #include "Physics/NuclearState/PauliBlocker.h"
 #include "Physics/QuasiElastic/XSection/QELUtils.h"
+#include "Physics/Common/QvalueShifter.h"
 
 namespace genie {
 
@@ -70,6 +71,7 @@ private:
   double                       fCos8c2;           ///< cos^2(cabibbo angle)
 
   double                       fXSecScale;        ///< external xsec scaling factor
+  const QvalueShifter *        fQvalueShifter ;   ///< Optional algorithm to retrieve the qvalue shift for a given target
 
   double                       fhbarc;            ///< hbar*c in GeV*fm
 


### PR DESCRIPTION
I decided to implement it only for Nieves, as it is what we wanna use for the tuning. Changing it more globally using the QEUtils::BindHitNucleon function was difficult, as within that function, I had no access to the information on the final state particles, hence, I could not calculate q0Tilde. I wanted to have a QvalueShift that had a similar meaning for 1p1h and 2p2h interactions, as the shift on 2p2h should be 2 the shift in 1p1h interactions. 