### PR TITLE
Origin/develop/mec scale vs w edges

### DIFF
--- a/config/MECScaleVsW.xml
+++ b/config/MECScaleVsW.xml
@@ -14,6 +14,11 @@ MECScaleVsW-LowerLimitQ3     vec-double   No         Vector of q3 at the lower l
                                                      phase space
 MECScaleVsW-Weights          vec-double   Yes        Vector of weights                             Default weight at the phase-space limits
 MECScaleVsW-WValues          vec-double   Yes        Vector of W values                            Default W values at phase-space limits
+
+MECScleVsW-LowerLimit-Weight double       Yes        Weight associated to the low limit of         MECScaleVsW-Default-Weight
+                                                     the phase space
+MECScleVsW-UpperLimit-Weight double       Yes        Weight associated to the upper limit of       MECScaleVsW-Default-Weight
+                                                     the phase space
 -->
 
   <param_set name="Default"> 

--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
@@ -88,7 +88,7 @@ MECScaleVsW::weight_type_map MECScaleVsW::GetMapWithLimits( const double Q0, con
   double max_weight = fDefaultWeight ; 
 
   if( fLowLimitWeight ) min_weight = *fLowLimitWeight ; 
-  if( fLowLimitWeight ) max_weight = *fUpperLimitWeight ; 
+  if( fUpperLimitWeight ) max_weight = *fUpperLimitWeight ; 
 
   w_map.insert( weight_type_pair( W_max, max_weight ) ) ;
   w_map.insert( weight_type_pair( W_min, min_weight ) ) ;

--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
@@ -147,13 +147,8 @@ void MECScaleVsW::LoadConfig(void)
     LOG("MECScaleVsW", pERROR) << "Lower limit for Q3 size: " << limit_Q3.size() ;
   }
 
-  if( GetConfig().Exists("MECScleVsW-LowerLimit-Weight") ) {
-    GetParam("MECScleVsW-LowerLimit-Weight", fLowLimitWeight ) ; 
-  } else { fLowLimitWeight = fDefaultWeight; } 
-
-  if( GetConfig().Exists("MECScleVsW-UpperLimit-Weight") ) {
-    GetParam("MECScleVsW-UpperLimit-Weight", fUpperLimitWeight ) ; 
-  } else { fUpperLimitWeight = fDefaultWeight ; }
+  GetParamDef("MECScleVsW-LowerLimit-Weight", fLowLimitWeight, fDefaultWeight ) ; 
+  GetParamDef("MECScleVsW-UpperLimit-Weight", fUpperLimitWeight, fDefaultWeight ) ; 
 
   if( ! good_config ) {
     LOG("MECScaleVsW", pERROR) << "Configuration has failed.";

--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
@@ -115,8 +115,11 @@ void MECScaleVsW::LoadConfig(void)
   if( GetConfig().Exists("MECScaleVsW-Default-Weight") ) {
     GetParam( "MECScaleVsW-Default-Weight", fDefaultWeight ) ;
   } else {
-    good_config = false ; 
-    LOG("MECScaleVsW", pERROR) << "Default weight is not specified " ;
+    if( ! GetConfig().Exists("MECScleVsW-LowLimit-Weight") || 
+	! GetConfig().Exists("MECScleVsW-UpperLimit-Weight") ) {
+      good_config = false ; 
+      LOG("MECScaleVsW", pERROR) << "Default weight is not specified. The physical limits weight cannot be set. " ;
+    }
   }
 
   std::vector<double> Weights, WValues ;

--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
@@ -84,14 +84,8 @@ MECScaleVsW::weight_type_map MECScaleVsW::GetMapWithLimits( const double Q0, con
 
   // Insert phase space limits:
   MECScaleVsW::weight_type_map w_map = fWeightsMap ; 
-  double min_weight = fDefaultWeight ; 
-  double max_weight = fDefaultWeight ; 
-
-  if( fLowLimitWeight ) min_weight = *fLowLimitWeight ; 
-  if( fUpperLimitWeight ) max_weight = *fUpperLimitWeight ; 
-
-  w_map.insert( weight_type_pair( W_max, max_weight ) ) ;
-  w_map.insert( weight_type_pair( W_min, min_weight ) ) ;
+  w_map.insert( weight_type_pair( W_max, fUpperLimitWeight ) ) ;
+  w_map.insert( weight_type_pair( W_min, fLowLimitWeight ) ) ;
 
   return w_map ; 
 } 
@@ -115,11 +109,8 @@ void MECScaleVsW::LoadConfig(void)
   if( GetConfig().Exists("MECScaleVsW-Default-Weight") ) {
     GetParam( "MECScaleVsW-Default-Weight", fDefaultWeight ) ;
   } else {
-    if( ! GetConfig().Exists("MECScleVsW-LowLimit-Weight") || 
-	! GetConfig().Exists("MECScleVsW-UpperLimit-Weight") ) {
       good_config = false ; 
-      LOG("MECScaleVsW", pERROR) << "Default weight is not specified. The physical limits weight cannot be set. " ;
-    }
+      LOG("MECScaleVsW", pERROR) << "Default weight is not specified." ;
   }
 
   std::vector<double> Weights, WValues ;
@@ -156,15 +147,13 @@ void MECScaleVsW::LoadConfig(void)
     LOG("MECScaleVsW", pERROR) << "Lower limit for Q3 size: " << limit_Q3.size() ;
   }
 
-  fLowLimitWeight = nullptr ; 
   if( GetConfig().Exists("MECScleVsW-LowerLimit-Weight") ) {
-    GetParam("MECScleVsW-LowerLimit-Weight", *fLowLimitWeight ) ; 
-  }
+    GetParam("MECScleVsW-LowerLimit-Weight", fLowLimitWeight ) ; 
+  } else { fLowLimitWeight = fDefaultWeight; } 
 
-  fUpperLimitWeight = nullptr ; 
   if( GetConfig().Exists("MECScleVsW-UpperLimit-Weight") ) {
-    GetParam("MECScleVsW-UpperLimit-Weight", *fUpperLimitWeight ) ; 
-  }
+    GetParam("MECScleVsW-UpperLimit-Weight", fUpperLimitWeight ) ; 
+  } else { fUpperLimitWeight = fDefaultWeight ; }
 
   if( ! good_config ) {
     LOG("MECScaleVsW", pERROR) << "Configuration has failed.";

--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.cxx
@@ -84,8 +84,14 @@ MECScaleVsW::weight_type_map MECScaleVsW::GetMapWithLimits( const double Q0, con
 
   // Insert phase space limits:
   MECScaleVsW::weight_type_map w_map = fWeightsMap ; 
-  w_map.insert( weight_type_pair( W_max, fDefaultWeight ) ) ;
-  w_map.insert( weight_type_pair( W_min, fDefaultWeight ) ) ;
+  double min_weight = fDefaultWeight ; 
+  double max_weight = fDefaultWeight ; 
+
+  if( fLowLimitWeight ) min_weight = *fLowLimitWeight ; 
+  if( fLowLimitWeight ) max_weight = *fUpperLimitWeight ; 
+
+  w_map.insert( weight_type_pair( W_max, max_weight ) ) ;
+  w_map.insert( weight_type_pair( W_min, min_weight ) ) ;
 
   return w_map ; 
 } 
@@ -145,6 +151,16 @@ void MECScaleVsW::LoadConfig(void)
     LOG("MECScaleVsW", pERROR) << "Entries don't match" ;
     LOG("MECScaleVsW", pERROR) << "Lower limit for Q0 size: " << limit_Q0.size() ;
     LOG("MECScaleVsW", pERROR) << "Lower limit for Q3 size: " << limit_Q3.size() ;
+  }
+
+  fLowLimitWeight = nullptr ; 
+  if( GetConfig().Exists("MECScleVsW-LowerLimit-Weight") ) {
+    GetParam("MECScleVsW-LowerLimit-Weight", *fLowLimitWeight ) ; 
+  }
+
+  fUpperLimitWeight = nullptr ; 
+  if( GetConfig().Exists("MECScleVsW-UpperLimit-Weight") ) {
+    GetParam("MECScleVsW-UpperLimit-Weight", *fUpperLimitWeight ) ; 
   }
 
   if( ! good_config ) {

--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.h
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.h
@@ -58,8 +58,8 @@ namespace genie {
     // Adding Spline to handle the limits of W1:
     TSpline3 fW1_Q0Q3_limits ; 
 
-    double * fLowLimitWeight ; 
-    double * fUpperLimitWeight ; 
+    double fLowLimitWeight ; 
+    double fUpperLimitWeight ; 
 
   };
   

--- a/src/Physics/Multinucleon/XSection/MECScaleVsW.h
+++ b/src/Physics/Multinucleon/XSection/MECScaleVsW.h
@@ -57,6 +57,10 @@ namespace genie {
     weight_type_map fWeightsMap ;
     // Adding Spline to handle the limits of W1:
     TSpline3 fW1_Q0Q3_limits ; 
+
+    double * fLowLimitWeight ; 
+    double * fUpperLimitWeight ; 
+
   };
   
 }       // genie namespace


### PR DESCRIPTION
In order to implement the new parameterization of the MECScaleVsW that we suggested in the last meeting, we need to be able to set the weight for both edges. In the previous implementation, this was the same parameter, defined by the default. 