### PR TITLE
For applications using histogram fluxes account for deficiency in GetRandom() if variable bin widths

### DIFF
--- a/src/Apps/gEvGen.cxx
+++ b/src/Apps/gEvGen.cxx
@@ -514,6 +514,22 @@ GFluxI * TH1FluxDriver(void)
         spectrum->SetBinContent(ibin, 0);
       }
     }
+    bool force_binwidth = false;
+#if ROOT_VERSION_CODE <= ROOT_VERSION(9,99,99)
+    // GetRandom() sampling on variable bin width histograms does not
+    // correctly account for bin widths for all versions of ROOT prior
+    // to (currently forever).  At some point this might change and
+    // the necessity of this code snippet will go away
+    TAxis* xaxis = spectrum->GetXaxis();
+    if (xaxis->IsVariableBinSize()) force_binwidth = true;
+#endif
+    if ( force_binwidth ) {
+      for(int ibin = 1; ibin <= spectrum->GetNbinsX(); ++ibin) {
+        double data = spectrum->GetBinContent(ibin);
+        double width = spectrum->GetBinWidth(ibin);
+        spectrum->SetBinContent(ibin,data*width);
+      }
+    }
 
     LOG("gevgen", pNOTICE) << spectrum->GetEntries();
 

--- a/src/Apps/gEvGenDM.cxx
+++ b/src/Apps/gEvGenDM.cxx
@@ -544,6 +544,23 @@ GFluxI * TH1FluxDriver(void)
         spectrum->SetBinContent(ibin, 0);
       }
     }
+    bool force_binwidth = false;
+#if ROOT_VERSION_CODE <= ROOT_VERSION(9,99,99)
+    // GetRandom() sampling on variable bin width histograms does not
+    // correctly account for bin widths for all versions of ROOT prior
+    // to (currently forever).  At some point this might change and
+    // the necessity of this code snippet will go away
+    TAxis* xaxis = spectrum->GetXaxis();
+    if (xaxis->IsVariableBinSize()) force_binwidth = true;
+#endif
+    if ( force_binwidth ) {
+      for(int ibin = 1; ibin <= spectrum->GetNbinsX(); ++ibin) {
+        double data = spectrum->GetBinContent(ibin);
+        double width = spectrum->GetBinWidth(ibin);
+        spectrum->SetBinContent(ibin,data*width);
+      }
+    }
+
 
     LOG("gevgen_dm", pNOTICE) << spectrum->GetEntries();
 

--- a/src/Apps/gFNALExptEvGen.cxx
+++ b/src/Apps/gFNALExptEvGen.cxx
@@ -144,32 +144,25 @@
                     each flux neutrino species you want to consider, eg
                     '-f somefile.root,12[nuehst],-12[nuebarhst],14[numuhst]'
                   - Code implicitly assumes the binning for multiple flavors
-                    is the same for all histograms
-                  - Variable bin width flux histograms are modified to account
-                    for incorrect sampling of TH1D::GetRandom() prior to ROOT
-                    version 9.99.99
-                    + notation such as "12[nuehst]WIDTH" forces bin width adjustment
-                      no matter variable bin width histogram or not
-                    + notation such as "12[nuehst]NOWIDTH" prevents bin width
-                      adjustment 
-                  - When using flux from histograms then there is no point in
-                    using a 'detailed detector geometry description' as your
-                    flux input contains no directional information for those
-                    flux neutrinos.
-                    The neutrino direction is conventionally set to be
-                      +z {x=0,y=0}.
-                    So, when using this option you must be using a simple
-                    'target mix'
-                    See the -g option for possible geometry settings.
-                    If you want to use the detailed detector geometry
-                    description then you should be using a driver that
-                    supplies a detailed simulated beam flux.
-                  - When using flux from histograms there is no branch with
-                    neutrino parent information added in the output event
-                    tree as your flux input contains no such information.
+                    is the same for all histograms (no checks are made)
                   - Note that the relative normalization of the flux histograms
                     is taken into account and is reflected in the relative
                     frequency of flux neutrinos thrown by the flux driver
+                  - Variable bin width flux histograms are modified to account
+                    for incorrect sampling of TH1D::GetRandom() prior to ROOT
+                    version 9.99.99
+                    + notation such as "12[nuehst]WIDTH" forces bin width
+                      adjustment no matter variable bin width histogram or not
+                    + notation such as "12[nuehst]NOWIDTH" prevents bin width
+                      adjustment
+                  - By default this is a beam of zero radius
+                    originating at (0,0,0) travelling in the direction (0,0,1)
+                    To override this append a string of the **exact** form:
+                      ";r=1.1,dir=(0.1,0.2,0.3),spot=(-1,-2,-3)"
+                    use exactly this layout (in order) with numbers modified
+                  - When using flux from histograms there is no branch with
+                    neutrino parent information added in the output event
+                    tree as your flux input contains no such information.
                   [Examples]
                   - To use the histogram 'h100' (representing the nu_mu flux)
                     and the histogram 'h300' (representing the nu_e flux) and
@@ -380,7 +373,13 @@ string          gOptFluxDriver = "";           // flux driver class to use
 map<string,string> gOptFluxShortNames;
 PDGCodeList     gOptFluxPdg;                   // list of neutrino flavors to accept
 map<int,double> gOptTgtMix;                    // target mix  (tgt pdg -> wght frac) / if not using detailed root geom
+
 map<int,TH1D*>  gOptFluxHst;                   // flux histos (nu pdg  -> spectrum)  / if not using beam sim ntuples
+TVector3        gOptBeamDir  = TVector3(0,0,1);
+TVector3        gOptBeamSpot = TVector3(0,0,0);
+Double_t        gOptBeamRadius   = -1; // meters
+string          gOptBeamRtDependence = "x";
+
 string          gOptRootGeom;                  // input ROOT file with realistic detector geometry
 string          gOptRootGeomTopVol = "";       // input geometry top event generation volume
 string          gOptRootGeomMasterVol = "";    // (highest level of geometry)
@@ -559,12 +558,11 @@ int main(int argc, char ** argv)
     }
 
     // creating & configuring a generic GCylindTH1Flux flux driver
-    TVector3 bdir (0,0,1); // dir along +z
-    TVector3 bspot(0,0,0);
+    hist_flux_driver->SetNuDirection      (gOptBeamDir);
+    hist_flux_driver->SetBeamSpot         (gOptBeamSpot);
+    hist_flux_driver->SetTransverseRadius (gOptBeamRadius);
+    //hist_flux_driver->SetRtDependence   (gOptBeamRtDependence); // "x");
 
-    hist_flux_driver->SetNuDirection      (bdir);
-    hist_flux_driver->SetBeamSpot         (bspot);
-    hist_flux_driver->SetTransverseRadius (-1);
     map<int,TH1D*>::iterator it = gOptFluxHst.begin();
     for( ; it != gOptFluxHst.end(); ++it) {
         int    pdg_code = it->first;
@@ -1641,14 +1639,69 @@ void ParseFluxHst(string flux)
   // Using flux from histograms
   // Extract the root file name & the list of histogram names & neutrino
   // species (specified as 'filename,histo1[species1],histo2[species2],...')
+  // possibly with configuration ";r=1.1,dir=(0.1,0.2,0.3),spot=(-1,-2,-3)"
+  // appended
   // See documentation on top section of this file.
-  //
 
-  vector<string> fluxv = utils::str::Split(flux,",");
+  vector<string> fluxtop = utils::str::Split(flux,";");
+  string beamsettings;
+  string histosettings;
+  if ( fluxtop.size() == 1 ) {
+    histosettings = fluxtop[0];
+    LOG("gevgen_fnal", pNOTICE)
+      << "ParseFluxHst: no settings for radius, direction, spot position"
+      << " using defaults, r=" << gOptBeamRadius;
+  } else if ( fluxtop.size() > 2 ) {
+    LOG("gevgen_fnal", pFATAL)
+      << "ParseFluxHst: too many ';' separated fields";
+    PrintSyntax();
+    exit(1);
+  } else {
+    // decide which is which depending on which has "=" in it
+    string::size_type eqpos0 = fluxtop[0].find("=");
+    string::size_type eqpos1 = fluxtop[1].find("=");
+    if        (eqpos0 == string::npos && eqpos1 != string::npos ) {
+      histosettings = fluxtop[0];
+      beamsettings  = fluxtop[1];
+    } else if (eqpos0 != string::npos && eqpos1 == string::npos ) {
+      beamsettings  = fluxtop[0];
+      histosettings = fluxtop[1];
+    } else {
+      LOG("gevgen_fnal", pFATAL)
+        << "ParseFluxHst: too many / not enough fields with '=' "
+        << "\n" << fluxtop[0] << "\n" << fluxtop[1];
+      PrintSyntax();
+      exit(1);
+    }
+    // now parse the string we have
+    double r=-1, dx=0, dy=0, dz=1, x=0, y=0, z=0;
+    int nscan = sscanf(beamsettings.c_str(),
+                       "r=%lf,dir=(%lf,%lf,%lf),spot=(%lf,%lf,%lf)",
+                       &r,&dx,&dy,&dz,&x,&y,&z);
+    cout << "nscan = " << nscan << endl;
+    gOptBeamRadius = r;
+    gOptBeamDir    = TVector3(dx,dy,dz);
+    gOptBeamSpot   = TVector3(x,y,z);
+
+  }
+  LOG("gevgen_fnal", pNOTICE)
+       << "ParseFluxHst: "
+       << " using r=" << gOptBeamRadius
+       << ",dir=("
+       << gOptBeamDir.Px() << ","
+       << gOptBeamDir.Py() << ","
+       << gOptBeamDir.Pz() << ")"
+       << ",spot=("
+       << gOptBeamSpot.X() << ","
+       << gOptBeamSpot.Y() << ","
+       << gOptBeamSpot.Z() << ")";
+
+
+  vector<string> fluxv = utils::str::Split(histosettings,",");
   if(fluxv.size()<2) {
     LOG("gevgen_fnal", pFATAL)
-      << "You need to specify both a flux ntuple ROOT file "
-      << " _AND_ a detector location";
+      << "You need to specify both a flux histogram ROOT file "
+      << " _AND_ at least one histogram[pdg] mapping";
     PrintSyntax();
     exit(1);
   }
@@ -1681,6 +1734,7 @@ void ParseFluxHst(string flux)
     string nutype = nutype_and_histo.substr(ibeg,iend-ibeg);
     string histo  = nutype_and_histo.substr(jbeg,jend-jbeg);
     string extra  = nutype_and_histo.substr(jend+1,string::npos);
+    std::transform(extra.begin(),extra.end(),extra.begin(),::toupper);
     LOG("gevgen_fnal", pNOTICE) // pDEBUG
       << " =======> nutype " << nutype << " histo " << histo << " extra " << extra;
     // access specified histogram from the input root file


### PR DESCRIPTION
Histograms with variable bin widths are not properly sampled by TH1D::GetRandom() -- only by height not by area so re-fill any variable bin width histograms with contents*width before handing them to the flux driver.  This is conditional on ROOT_VERSION < 9.99.99 which can be changed if in the future the behavior is corrected.