### PR TITLE
add #include RunOpt.h because otherwise treated as an incomplete class

### DIFF
--- a/src/scripts/gcint/genie_setup.C
+++ b/src/scripts/gcint/genie_setup.C
@@ -32,6 +32,7 @@ void genie_setup()
 
     change_prompt();
     
+    gROOT->ProcessLine("#include \"Framework/Utils/RunOpt.h\"" ) ;
     gROOT->ProcessLine("genie::RunOpt::Instance()->ReadFromCommandLine( 0, 0 );" ) ;
     gROOT->ProcessLine("genie::RunOpt::Instance()->BuildTune();");
 


### PR DESCRIPTION
I'm not sure what changed, but the use of "genie::RunOpt::Instance()" was failing with v3_02_00 and root v6_22_08 because it was seen an an incomplete class.  By pulling in the header the genie-as-a-super-root works again cleanly