### PR TITLE
have GSimpleNtpFlux driver do the right thing with times by default, …

### DIFF
--- a/src/Tools/Flux/GSimpleNtpFlux.cxx
+++ b/src/Tools/Flux/GSimpleNtpFlux.cxx
@@ -738,7 +738,7 @@ void GSimpleNtpFlux::Initialize(void)
   fAllFilesMeta    = true;
   fAlreadyUnwgt    = false;
 
-  fIncludeVtxt     = false;
+  fIncludeVtxt     = true;
 
   this->SetDefaults();
   this->ResetCurrent();


### PR DESCRIPTION
…even if not backward compatible