### PR TITLE
removing safety factor for Wcut

### DIFF
--- a/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.cxx
+++ b/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.cxx
@@ -191,16 +191,16 @@ double KNOTunedQPMDISPXSec::DISRESJoinSuppressionFactor(
     } // cache data
 
     // get the reduction factor from the cache branch
-    if(Wo > Wmin && Wo < fWcut-1E-2) {
+    if(Wo > Wmin && Wo < fWcut) {
        const CacheBranchFx & cache_branch = (*cbr);
        R = cache_branch(Wo);
     }
   }
 
   // Now return the suppression factor
-  if      (Wo > Wmin && Wo < fWcut-1E-2) Ro = R;
-  else if (Wo <= Wmin)                   Ro = 0.0;
-  else                                   Ro = 1.0;
+  if      (Wo > Wmin && Wo < fWcut) Ro = R;
+  else if (Wo <= Wmin)            Ro = 0.0;
+  else                            Ro = 1.0;
 
   LOG("DISXSec", pDEBUG)
       << "DIS/RES Join: DIS xsec suppr. (W=" << Wo << ") = " << Ro;


### PR DESCRIPTION
We noticed some double counting in electron scattering inclusive plots. This was due to a correction factor applied to fWcut. This correction  isn't needed as we are already calculating the cross sections above Wcut before merging them together. We can safely remove this additional correction factor. 
This pull request was discussed in the latest GENIE Tuning meeting (https://genie-docdb.pp.rl.ac.uk/cgi-bin/private/ShowDocument?docid=320) 