### PR TITLE
don't pass rootcling Geant4's non -I cflags

### DIFF
--- a/src/Physics/HadronTransport/Makefile
+++ b/src/Physics/HadronTransport/Makefile
@@ -29,22 +29,22 @@ include $(GENIE)/src/make/Make.std-package-targets
 
 ifeq ($(strip $(GOPT_ENABLE_INCL)),YES)
   # extra flags, include paths, and libraries to link to
-  CXXFLAGS               += $(INCL_FLAGS)
+  CXXFLAGS               += $(INCL_DFLAGS)
   CPP_INCLUDES           += $(INCL_INCLUDES)
-  ROOT_DICT_GEN_INCLUDES += $(INCL_INCLUDES) ${INCL_FLAGS}
+  ROOT_DICT_GEN_INCLUDES += $(INCL_INCLUDES) $(INCL_DFLAGS)
   EXTRA_EXT_LIBS         += $(INCL_LIBRARIES)
 else
-  $(info $(PACKAGE) not build against INCL++)
+  $(info $(PACKAGE) not built against INCL++)
 endif
 
 ifeq ($(strip $(GOPT_ENABLE_GEANT4_INTERFACE)),YES)
   # extra flags, include paths, and libraries to link to
   CXXFLAGS               += $(GEANT4_FLAGS)
   CPP_INCLUDES           += $(GEANT4_INCLUDES)
-  ROOT_DICT_GEN_INCLUDES += $(GEANT4_INCLUDES) ${GEANT4_FLAGS}
+  ROOT_DICT_GEN_INCLUDES += $(GEANT4_INCLUDES)
   EXTRA_EXT_LIBS         += $(GEANT4_LIBRARIES)
 else
-  $(info $(PACKAGE) not build against Geant4)
+  $(info $(PACKAGE) not built against Geant4)
 endif
 
 FORCE:

--- a/src/make/Make.include
+++ b/src/make/Make.include
@@ -177,7 +177,7 @@ INCL_INCLUDES  =
 ifeq ($(strip $(GOPT_ENABLE_INCL)),YES)
 
 INCL_INCLUDES  = -I$(GOPT_WITH_INCL_INC) -I$(GOPT_WITH_BOOST_INC)
-INCL_FLAGS     = $(shell $(GOPT_WITH_INCL_LIB)/../bin/inclxx-config --dflags )
+INCL_DFLAGS    = $(shell $(GOPT_WITH_INCL_LIB)/../bin/inclxx-config --dflags )
 INCL_LIBRARIES = -L$(GOPT_WITH_INCL_LIB)  $(shell $(GOPT_WITH_INCL_LIB)/../bin/inclxx-config --libs )
 
 BOOST_LIBRARIES = -L$(GOPT_WITH_BOOST_LIB) -lboost_program_options -lboost_timer -lboost_system -lboost_date_time
@@ -210,7 +210,6 @@ G4_IFLAGS_ONLY = $(filter     -I%,$(GEANT4_CFLAGS))
 
 # this might be -I/path/include/ or -I/path/include/Geant
 # really want the first
-#GEANT4_INCLUDES += -DG4_INC_START $(G4_IFLAGS_ONLY) -DG4_INC_END
 GEANT4_INCLUDES += $(G4_IFLAGS_ONLY)
 
 G4INCBASE = $(strip $(filter -I%include/Geant4,$(G4_IFLAGS_ONLY)))


### PR DESCRIPTION
newer versions of rootcling object to -p flags that using all of Geant4's cflags bring to the table.