### PR TITLE
Fix Nuclear tune README

### DIFF
--- a/config/GPRD18_10a/MECScaleVsW.xml
+++ b/config/GPRD18_10a/MECScaleVsW.xml
@@ -31,8 +31,8 @@ MECScleVsW-UpperLimit-Weight double       Yes        Weight associated to the up
     <!-- Tune specific parameters --> 
 
     <!-- Tuned to: 
-      - G10a: MicroBooNE numu CCQELike data 
-      - G11a: MicroBooNE numubar CCQELike data 
+      - G10a: MiniBooNE numu CCQELike data 
+      - G11a: MiniBooNE numubar CCQELike data 
       - G20a: T2K numu CC0p0pi data 
       - G30a: MINERvA numu CC0pi data
       - G31a: MINERvA numubar CC0p0pi data

--- a/config/GPRD18_10a/README.md
+++ b/config/GPRD18_10a/README.md
@@ -1,9 +1,9 @@
 # Configuring Nuclear Partial tunes on CC0pi data
 GENIE published a number of partial tunes to CC0pi data (https://journals.aps.org/prd/abstract/10.1103/PhysRevD.106.112001). Each tune was performed against a different set of data: 
 
-      - G10a: MicroBooNE numu CCQELike data
+      - G10a: MiniBooNE numu CCQELike data
 
-      - G11a: MicroBooNE numubar CCQELike data
+      - G11a: MiniBooNE numubar CCQELike data
 
       - G20a: T2K numu CC0p0pi data           
 

--- a/config/GPRD18_10a/XSecLinearCombinations.xml
+++ b/config/GPRD18_10a/XSecLinearCombinations.xml
@@ -26,8 +26,8 @@ Normalise              bool       No         Sum of coefficients = 1            
     <!-- Tune specific parameters --> 
 
     <!-- Tuned to: 
-      - G10a: MicroBooNE numu CCQELike data 
-      - G11a: MicroBooNE numubar CCQELike data 
+      - G10a: MiniBooNE numu CCQELike data 
+      - G11a: MiniBooNE numubar CCQELike data 
       - G20a: T2K numu CC0p0pi data 
       - G30a: MINERvA numu CC0pi data
       - G31a: MINERvA numubar CC0p0pi data


### PR DESCRIPTION
The readme was pointing out to the wrong experiment. The tunes were performed with MiniBooNE data