### PR TITLE
Small fix on CRPA implementation

### DIFF
--- a/src/Physics/QuasiElastic/XSection/SuSAv2QELPXSec.cxx
+++ b/src/Physics/QuasiElastic/XSection/SuSAv2QELPXSec.cxx
@@ -162,7 +162,7 @@ double SuSAv2QELPXSec::XSec(const Interaction* interaction,
   else {
     // If the probe is not a neutrino, assume that it's an electron
     // Currently only avaialble for SuSA. CRPA coming soon(ish)!
-    tensor_pdg_susa = kHT_QE_EM;
+    tensor_type_susa = kHT_QE_EM;
   }
 
   double Eb_tgt=0;


### PR DESCRIPTION
The new implementation of CRPA was failing to load the EM hadron tensors due to a small typo in the code. As a consequence, a warning was printed, and the cross section was 0. 
@sjdolan suggested the change. 
