### PR TITLE
fixing typo

### DIFF
--- a/src/Physics/QuasiElastic/XSection/SuSAv2QELPXSec.cxx
+++ b/src/Physics/QuasiElastic/XSection/SuSAv2QELPXSec.cxx
@@ -162,7 +162,7 @@ double SuSAv2QELPXSec::XSec(const Interaction* interaction,
   else {
     // If the probe is not a neutrino, assume that it's an electron
     // Currently only avaialble for SuSA. CRPA coming soon(ish)!
-    tensor_pdg_susa = kHT_QE_EM;
+    tensor_type_susa = kHT_QE_EM;
   }
 
   double Eb_tgt=0;


### PR DESCRIPTION
Julia tested the updated SuSAv2 and co models with EM scattering and found an issue. We quickly traced this down to a silly typo when I was expanding the SuSA code to work for CRPA as well. This is now fixed. 