### PR TITLE
fix RESKinematicsGenerator

### DIFF
--- a/src/Framework/Utils/KineUtils.cxx
+++ b/src/Framework/Utils/KineUtils.cxx
@@ -1373,7 +1373,7 @@ double genie::utils::kinematics::RESImportanceSamplingEnvelope(
                                                      double * x, double * par)
 {
   //-- inputs
-  double QD2   = x[0];   // QD2 (Q2 transformed to take out the dipole form)
+  double Q2    = x[0];   // Q2
   double W     = x[1];   // invariant mass
 
   //-- parameters
@@ -1424,8 +1424,8 @@ double genie::utils::kinematics::RESImportanceSamplingEnvelope(
      }
   }
 
-  if(QD2<0.5) {
-    func *= (1 - (0.5-QD2));
+  if(Q2>controls::kMQD2) {
+    func *= (0.5 + 1./(1 + Q2/controls::kMQD2));
   }
 
   return func;


### PR DESCRIPTION
Fixing of the problem with `RESKinematicsGenerator` reported in issue #282 .

I suggest getting rid of the variable `QD2` to avoid confusion with Jacobian, variable transformation and global maximum searching. The function `double genie::utils::kinematics::RESImportanceSamplingEnvelope(double * x, double * par)` is used only in _RESKinematicsGenerator.cxx_, therefore it should not cause problems anywhere else. All changes are trivial.