### PR TITLE
Fix edge issue in GMCJDriver

### DIFF
--- a/src/Framework/EventGen/GMCJDriver.cxx
+++ b/src/Framework/EventGen/GMCJDriver.cxx
@@ -653,7 +653,7 @@ void GMCJDriver::BootstrapXSecSplineSummation(void)
     // to avoid the evaluation of the cubic spline around the viscinity of
     // knots with zero y values (although the GENIE Spline object handles it)
     double min = rE.min;
-    double max = rE.max;
+    double max = TMath::Min(rE.max, fEmax);
     
     // Because of edge issue (see GENIE docdb 297) these lines are commented out
     //    double dE  = fEmax/10.;


### PR DESCRIPTION
Now, the maximum energy of the spline built inside the `GMCJDriver` is defined as the maximum of validity energy range for this generator. Sometimes there are cases when the splines are pre-calculated in a range whose maximum is lower than the maximum of the validity energy range. In such cases, the total cross section spline is incorrect at the highest energies and the generated events are skewed. 