### PR TITLE
Addressing EM RES issue

### DIFF
--- a/src/Physics/Resonance/XSection/BSKLNBaseRESPXSec2014.cxx
+++ b/src/Physics/Resonance/XSection/BSKLNBaseRESPXSec2014.cxx
@@ -327,7 +327,7 @@ double BSKLNBaseRESPXSec2014::XSec(
 
     LOG("BSKLNBaseRESPXSec2014",pINFO) <<"GA= " <<GA << "  C5A= " <<CA5;
   } else { 
-    LOG("BSKLNBaseRESPXSec2014",pDEBUG << "Using dipole parametrization for GV") ;
+    LOG("BSKLNBaseRESPXSec2014",pDEBUG << "Using dipole parametrization for GA") ;
   }
 
   if(is_EM) {

--- a/src/Physics/Resonance/XSection/BSKLNBaseRESPXSec2014.cxx
+++ b/src/Physics/Resonance/XSection/BSKLNBaseRESPXSec2014.cxx
@@ -766,6 +766,7 @@ void BSKLNBaseRESPXSec2014::LoadConfig(void)
   // Cross section scaling factors
   this->GetParam( "RES-CC-XSecScale", fXSecScaleCC ) ;
   this->GetParam( "RES-NC-XSecScale", fXSecScaleNC ) ;
+  this->GetParam( "RES-EM-XSecScale", fXSecScaleEM ) ;
 
   // Load all configuration data or set defaults
 


### PR DESCRIPTION
The new RES-EM Scaling parameter was not loaded in the BS xsec class. As a consequence, it was given a very small number, causing the xsec calculation to be always 0. This PR fixes this. I had a close look at the other processes. This behaviour is not observed, indicating the only problematic process was EMRES for the BS model.