### PR TITLE
Change configuration for  Diffractive event generator

### DIFF
--- a/config/EventGenerator.xml
+++ b/config/EventGenerator.xml
@@ -503,31 +503,25 @@ XSecModel                   alg     Yes  Cross section model used at the thread 
 
   <param_set name="DFR-CC">
      <param type="string" name="VldContext"> </param>
-     <param type="int"    name="NModules">   9                                                   </param>
+     <param type="int"    name="NModules">   6                                                   </param>
      <param type="alg"    name="Module-0">   genie::InitialStateAppender/Default                 </param>
      <param type="alg"    name="Module-1">   genie::VertexGenerator/Default                      </param>
-     <param type="alg"    name="Module-2">   genie::FermiMover/NucOnShell                        </param>
-     <param type="alg"    name="Module-3">   genie::DFRKinematicsGenerator/Default               </param>
-     <param type="alg"    name="Module-4">   genie::DFRPrimaryLeptonGenerator/Default            </param>
-     <param type="alg"    name="Module-5">   genie::DFRHadronicSystemGenerator/Default           </param>
-     <param type="alg"    name="Module-6">   genie::UnstableParticleDecayer/BeforeHadronTransport</param>
-     <param type="alg"    name="Module-7">   genie::HadronTransporter/Default                    </param>
-     <param type="alg"    name="Module-8">   genie::UnstableParticleDecayer/AfterHadronTransport </param>
+     <param type="alg"    name="Module-2">   genie::DFRKinematicsGenerator/Default               </param>
+     <param type="alg"    name="Module-3">   genie::DFRPrimaryLeptonGenerator/Default            </param>
+     <param type="alg"    name="Module-4">   genie::DFRHadronicSystemGenerator/Default           </param>
+     <param type="alg"    name="Module-5">   genie::UnstableParticleDecayer/AfterHadronTransport </param>
      <param type="alg"    name="ILstGen">    genie::DFRInteractionListGenerator/CC-Default       </param>
   </param_set>
 
   <param_set name="DFR-NC">
      <param type="string" name="VldContext"> </param>
-     <param type="int"    name="NModules">   9                                                   </param>
+     <param type="int"    name="NModules">   6                                                   </param>
      <param type="alg"    name="Module-0">   genie::InitialStateAppender/Default                 </param>
      <param type="alg"    name="Module-1">   genie::VertexGenerator/Default                      </param>
-     <param type="alg"    name="Module-2">   genie::FermiMover/NucOnShell                        </param>
-     <param type="alg"    name="Module-3">   genie::DFRKinematicsGenerator/Default               </param>
-     <param type="alg"    name="Module-4">   genie::DFRPrimaryLeptonGenerator/Default            </param>
-     <param type="alg"    name="Module-5">   genie::DFRHadronicSystemGenerator/Default           </param>
-     <param type="alg"    name="Module-6">   genie::UnstableParticleDecayer/BeforeHadronTransport</param>
-     <param type="alg"    name="Module-7">   genie::HadronTransporter/Default                    </param>
-     <param type="alg"    name="Module-8">   genie::UnstableParticleDecayer/AfterHadronTransport </param>
+     <param type="alg"    name="Module-2">   genie::DFRKinematicsGenerator/Default               </param>
+     <param type="alg"    name="Module-3">   genie::DFRPrimaryLeptonGenerator/Default            </param>
+     <param type="alg"    name="Module-4">   genie::DFRHadronicSystemGenerator/Default           </param>
+     <param type="alg"    name="Module-5">   genie::UnstableParticleDecayer/AfterHadronTransport </param>
      <param type="alg"    name="ILstGen">    genie::DFRInteractionListGenerator/NC-Default       </param>
   </param_set>
 


### PR DESCRIPTION
The diffractive scattering this is a process like $\nu_\mu + p \rightarrow \mu^- + \pi^+ + p$ and $\bar\nu_\mu + p \rightarrow \mu^+ + \pi^- + p$ (see e.g Phys. Rev. D 97 (2018) 032014 or Nucl. Phys. B 278 (1986) 61-77). The typical diffractive event looks like:
```
|------------------------------------------------------------------------------------------------------------------|
|GENIE GHEP Event Record [print level:   3]                                                                        |
|------------------------------------------------------------------------------------------------------------------|
| Idx |          Name | Ist |        PDG |   Mother  | Daughter  |      Px |      Py |      Pz |       E |      m  | 
|------------------------------------------------------------------------------------------------------------------|
|   0 |         nu_mu |   0 |         14 |  -1 |  -1 |   2 |   2 |   0.000 |   0.000 |   9.274 |   9.274 |   0.000 | 
|   1 |        proton |   0 |       2212 |  -1 |  -1 |   3 |   4 |   0.000 |   0.000 |   0.000 |   0.938 |   0.938 | 
|   2 |           mu- |   1 |         13 |   0 |  -1 |  -1 |  -1 |  -0.180 |  -0.155 |   6.267 |   6.273 |   0.106 | P = (0.029,0.025,-0.999)
|   3 |        proton |   1 |       2212 |   1 |  -1 |  -1 |  -1 |   0.075 |  -0.191 |   0.055 |   0.962 |   0.938 | 
|   4 |           pi+ |   1 |        211 |   1 |  -1 |  -1 |  -1 |   0.104 |   0.346 |   2.953 |   2.978 |   0.140 | 
|------------------------------------------------------------------------------------------------------------------|
|       Fin-Init:                                                |   0.000 |   0.000 |   0.000 |   0.000 |         | 
|------------------------------------------------------------------------------------------------------------------|
|       Vertex:          nu_mu @ (x =     0.00000 m, y =     0.00000 m, z =     0.00000 m, t =    0.000000e+00 s)  |
|------------------------------------------------------------------------------------------------------------------|
| Err flag [bits:15->0] : 0000000000000000    |  1st set:                                                     none | 
| Err mask [bits:15->0] : 1111111111111111    |  Is unphysical:    NO |   Accepted:   YES                          |
|------------------------------------------------------------------------------------------------------------------|
| sig(Ev) =       1.12746e-39 cm^2  | d3sig(x,y,t;E)/dxdydt =   4.35524e-38 cm^2/GeV^2 | Weight =          1.00000 |
|------------------------------------------------------------------------------------------------------------------|

--------------------------------------------------------------------------------------------------------------
GENIE Interaction Summary
--------------------------------------------------------------------------------------------------------------
[-] [Init-State] 
 |--> probe        : PDG-code = 14 (nu_mu)
 |--> nucl. target : Z = 1, A = 1, PDG-Code = 1000010010 (H1)
 |--> hit nucleon  : PDC-Code = 2212 (proton)
 |--> hit quark    : no set
 |--> probe 4P     : (E =     9.274294, Px =     0.000000, Py =     0.000000, Pz =     9.274294)
 |--> target 4P    : (E =     0.938272, Px =     0.000000, Py =     0.000000, Pz =     0.000000)
 |--> nucleon 4P   : (E =     0.938272, Px =     0.000000, Py =     0.000000, Pz =     0.000000)
[-] [Process-Info]  
 |--> Interaction : Weak[CC]
 |--> Scattering  : DFR
[-] [Kinematics]
 |--> *Selected* Bjorken x = 0.015741
 |--> *Selected* Inelasticity y = 0.323659
 |--> *Selected* Momentum transfer Q2 (>0) = 0.088668
 |--> *Selected* Hadronic invariant mass W = 2.534665
 |--> *Selected* COH 4p transfer to nucleus = 0.044689
[-] [Exclusive Process Info] 
 |--> charm prod.  : false |--> strange prod.  : false
 |--> f/s nucleons : N(p) = 1 N(n) = 0
 |--> f/s pions    : N(pi^0) = 0 N(pi^+) = 1 N(pi^-) = 0
 |--> f/s Other    : N(gamma) = 0 N(Rho^0) = 0 N(Rho^+) = 0 N(Rho^-) = 0
 |--> resonance    : [not set]
 |--> final quark prod.  : false
 |--> final lepton prod.  : false
--------------------------------------------------------------------------------------------------------------
```

Therefore, event generator for diffractive events must not have Fermi Movier, Hadron Transporter. That is, it should be like coherent event generator.