### PR TITLE
Config cleanup

### DIFF
--- a/config/AR23_20i/CommonParam.xml
+++ b/config/AR23_20i/CommonParam.xml
@@ -157,41 +157,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/CommonParam.xml
+++ b/config/CommonParam.xml
@@ -155,41 +155,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/EX00_00a/CommonParam.xml
+++ b/config/EX00_00a/CommonParam.xml
@@ -154,42 +154,6 @@ University of Liverpool
 
   </param_set>
 
-
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_01a/G18_01a_02_11a/CommonParam.xml
+++ b/config/G18_01a/G18_01a_02_11a/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_01a/G18_01a_02_11b/CommonParam.xml
+++ b/config/G18_01a/G18_01a_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_01b/G18_01b_02_11a/CommonParam.xml
+++ b/config/G18_01b/G18_01b_02_11a/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_01b/G18_01b_02_11b/CommonParam.xml
+++ b/config/G18_01b/G18_01b_02_11b/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02a/G18_02a_02_11a/CommonParam.xml
+++ b/config/G18_02a/G18_02a_02_11a/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02a/G18_02a_02_11b/CommonParam.xml
+++ b/config/G18_02a/G18_02a_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02a/G18_02a_03_320/CommonParam.xml
+++ b/config/G18_02a/G18_02a_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02a/G18_02a_03_330/CommonParam.xml
+++ b/config/G18_02a/G18_02a_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02b/G18_02b_02_11a/CommonParam.xml
+++ b/config/G18_02b/G18_02b_02_11a/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02b/G18_02b_02_11b/CommonParam.xml
+++ b/config/G18_02b/G18_02b_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02c/G18_02c_02_11a/CommonParam.xml
+++ b/config/G18_02c/G18_02c_02_11a/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02c/G18_02c_02_11b/CommonParam.xml
+++ b/config/G18_02c/G18_02c_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02c/G18_02c_03_320/CommonParam.xml
+++ b/config/G18_02c/G18_02c_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02c/G18_02c_03_330/CommonParam.xml
+++ b/config/G18_02c/G18_02c_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02d/G18_02d_02_11a/CommonParam.xml
+++ b/config/G18_02d/G18_02d_02_11a/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02d/G18_02d_02_11b/CommonParam.xml
+++ b/config/G18_02d/G18_02d_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02d/G18_02d_03_320/CommonParam.xml
+++ b/config/G18_02d/G18_02d_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_02d/G18_02d_03_330/CommonParam.xml
+++ b/config/G18_02d/G18_02d_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10a/G18_10a_02_11a/CommonParam.xml
+++ b/config/G18_10a/G18_10a_02_11a/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10a/G18_10a_02_11b/CommonParam.xml
+++ b/config/G18_10a/G18_10a_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10a/G18_10a_03_320/CommonParam.xml
+++ b/config/G18_10a/G18_10a_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10a/G18_10a_03_330/CommonParam.xml
+++ b/config/G18_10a/G18_10a_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10b/G18_10b_02_11b/CommonParam.xml
+++ b/config/G18_10b/G18_10b_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10c/G18_10c_02_11a/CommonParam.xml
+++ b/config/G18_10c/G18_10c_02_11a/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10c/G18_10c_02_11b/CommonParam.xml
+++ b/config/G18_10c/G18_10c_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10c/G18_10c_03_320/CommonParam.xml
+++ b/config/G18_10c/G18_10c_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10c/G18_10c_03_330/CommonParam.xml
+++ b/config/G18_10c/G18_10c_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10d/G18_10d_02_11a/CommonParam.xml
+++ b/config/G18_10d/G18_10d_02_11a/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10d/G18_10d_02_11b/CommonParam.xml
+++ b/config/G18_10d/G18_10d_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10d/G18_10d_03_320/CommonParam.xml
+++ b/config/G18_10d/G18_10d_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10d/G18_10d_03_330/CommonParam.xml
+++ b/config/G18_10d/G18_10d_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10i/G18_10i_02_11a/CommonParam.xml
+++ b/config/G18_10i/G18_10i_02_11a/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10i/G18_10i_02_11b/CommonParam.xml
+++ b/config/G18_10i/G18_10i_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10i/G18_10i_03_320/CommonParam.xml
+++ b/config/G18_10i/G18_10i_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10i/G18_10i_03_330/CommonParam.xml
+++ b/config/G18_10i/G18_10i_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10j/G18_10j_02_11a/CommonParam.xml
+++ b/config/G18_10j/G18_10j_02_11a/CommonParam.xml
@@ -164,41 +164,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10j/G18_10j_02_11b/CommonParam.xml
+++ b/config/G18_10j/G18_10j_02_11b/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10j/G18_10j_03_320/CommonParam.xml
+++ b/config/G18_10j/G18_10j_03_320/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G18_10j/G18_10j_03_330/CommonParam.xml
+++ b/config/G18_10j/G18_10j_03_330/CommonParam.xml
@@ -163,41 +163,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G21_11a/CommonParam.xml
+++ b/config/G21_11a/CommonParam.xml
@@ -162,45 +162,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
-
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G21_11b/CommonParam.xml
+++ b/config/G21_11b/CommonParam.xml
@@ -162,46 +162,7 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
-
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
- <param_set name="Coherent">
+  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>
 

--- a/config/G21_11c/CommonParam.xml
+++ b/config/G21_11c/CommonParam.xml
@@ -162,45 +162,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
-
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/G21_11d/CommonParam.xml
+++ b/config/G21_11d/CommonParam.xml
@@ -162,45 +162,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
-
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/GEM21_11a/CommonParam.xml
+++ b/config/GEM21_11a/CommonParam.xml
@@ -162,45 +162,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
-
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/GEM21_11b/CommonParam.xml
+++ b/config/GEM21_11b/CommonParam.xml
@@ -173,34 +173,6 @@ University of Liverpool
  -->
 
 
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/GEM21_11c/CommonParam.xml
+++ b/config/GEM21_11c/CommonParam.xml
@@ -154,45 +154,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
-
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/GEM21_11d/CommonParam.xml
+++ b/config/GEM21_11d/CommonParam.xml
@@ -154,45 +154,6 @@ University of Liverpool
  </param_set>
 
 
- <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-      Probably these should all be moved in the local configurations
- -->
-
-
- <!-- DEFAULT: <param type="double" name="INUKE-HadStep">           0.05  </param> -->
- <!-- ExFSI: <param type="double" name="INUKE-HadStep">           0.025  </param> -->
-
- <param_set name="INUKE">
-   <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-   <param type="double" name="INUKE-HadStep">           0.05  </param>
-   <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-   <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-   <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-   <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-   <param type="double" name="INUKE-FermiFac">          1.0   </param>
-   <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-   <param type="bool"   name="INUKE-DoFermi">           true  </param>
-   <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-   <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
- </param_set>
-
- <param_set name="HAINUKE">
-   <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-   <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
- </param_set>
-
- <param_set name="HNINUKE">
-   <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-   <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-   <param type="bool"   name="HNINUKE-UseOset">         true  </param>
- </param_set>
-
  <param_set name="Coherent">
 
    <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/GPRD18_10a/GPRD18_10a_02_11b/CommonParam.xml
+++ b/config/GPRD18_10a/GPRD18_10a_02_11b/CommonParam.xml
@@ -157,41 +157,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/GVLE18_01a/CommonParam.xml
+++ b/config/GVLE18_01a/CommonParam.xml
@@ -155,41 +155,6 @@ University of Liverpool
   </param_set>
 
 
-  <!--
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      INTRANUKE-specific parameters:
-      - Mode options are: hA, hN
-      - NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
-      - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
-
-Probably these should all be moved in the local configurations
-  -->
-
-  <param_set name="INUKE">
-    <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
-    <param type="double" name="INUKE-HadStep">           0.05  </param>
-    <param type="double" name="INUKE-NucAbsFac">         1.0   </param>
-    <param type="double" name="INUKE-NucQEFac">          1.0   </param>
-    <param type="double" name="INUKE-NucCEXFac">         1.0   </param>
-    <param type="double" name="INUKE-Energy_Pre_Eq">     0.041 </param>
-    <param type="double" name="INUKE-FermiFac">          1.0   </param>
-    <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
-    <param type="bool"   name="INUKE-DoFermi">           true  </param>
-    <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
-    <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
-  </param_set>
-
-  <param_set name="HAINUKE">
-    <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
-    <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>
-  </param_set>
-
-  <param_set name="HNINUKE">
-    <param type="double" name="HNINUKE-DelRPion">        0.0   </param>
-    <param type="double" name="HNINUKE-DelRNucleon">     0.0   </param>
-    <param type="bool"   name="HNINUKE-UseOset">         true  </param>
-  </param_set>
-
   <param_set name="Coherent">
 
     <param type="double" name="COH-Ro"> 1.000 </param>

--- a/config/HAIntranuke.xml
+++ b/config/HAIntranuke.xml
@@ -34,6 +34,9 @@ DelRNucleon         double  Yes   mult. factor for nucleon de-Broglie wavelength
 	 were tuned using genie::FGMBodekRitchie/Default.
 	 If a systematic validation is desired we recommend to switch this to
 	  <param type="alg"    name="NuclearModel"> genie::FGMBodekRitchie/Default </param>
+
+   NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
+
     -->
 
     <param type="bool"   name="INUKE-DoFermi">           true  </param>
@@ -47,6 +50,10 @@ DelRNucleon         double  Yes   mult. factor for nucleon de-Broglie wavelength
     <param type="double" name="INUKE-FermiFac">          1.0   </param>
     <param type="double" name="INUKE-FermiMomentum">     0.250 </param>
     <param type="double" name="INUKE-FreeStep">          0.0   </param>
+
+    <!--
+    - typical values for pion, nucleon DelR are 0.5, 0.7 (hA) and 0.2, 0.2 (hN)
+    -->
 
     <param type="double" name="HAINUKE-DelRPion">        0.5   </param>
     <param type="double" name="HAINUKE-DelRNucleon">     0.7   </param>

--- a/config/HAIntranuke2018.xml
+++ b/config/HAIntranuke2018.xml
@@ -34,7 +34,9 @@ DelRNucleon         double  Yes   mult. factor for nucleon de-Broglie wavelength
 	 were tuned using genie::FGMBodekRitchie/Default.
 	 If a systematic validation is desired we recommend to switch this to
 	  <param type="alg"    name="NuclearModel"> genie::FGMBodekRitchie/Default </param>
-    -->
+
+   NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
+  -->
 
     <param type="double" name="INUKE-NucRemovalE">       0.00  </param>
     <param type="double" name="INUKE-HadStep">           0.05  </param>
@@ -49,6 +51,8 @@ DelRNucleon         double  Yes   mult. factor for nucleon de-Broglie wavelength
     <param type="bool"   name="INUKE-DoFermi">           true  </param>
     <param type="bool"   name="INUKE-DoCompoundNucleus"> true  </param>
     <param type="bool"   name="INUKE-XsecNNCorr">        true  </param>
+
+ 
 
     <param type="double" name="HAINUKE-DelRPion">        0.0   </param>
     <param type="double" name="HAINUKE-DelRNucleon">     0.0   </param>

--- a/config/HNIntranuke2018.xml
+++ b/config/HNIntranuke2018.xml
@@ -38,6 +38,9 @@ XsecNNCorr          bool    Yes   nuclear medium correction for NN cross section
 	 were tuned using genie::FGMBodekRitchie/Default.
 	 If a systematic validation is desired we recommend to switch this to 
 	  <param type="alg"    name="NuclearModel"> genie::FGMBodekRitchie/Default </param>
+
+   NucRemovalE is the binding E to subtract from cascade nucleons (in GeV)
+
     -->
 
     <param type="bool" name="HNINUKE-UseOset"> true  </param>


### PR DESCRIPTION
While working on the TKI tuning, we realised some INUKE related entries in `CommonParam.xml` files were completely obsolete and created confusion.

Comments were moved in `H*Intranuke*.xml` and the blocks were removed as they were not even read from the code. 