### PR TITLE
Adding Wmin for Non-RES background

### DIFF
--- a/config/KNOTunedQPMDISPXSec.xml
+++ b/config/KNOTunedQPMDISPXSec.xml
@@ -12,6 +12,7 @@ DISModel                    alg     no    It must be QPMDISPXSec
 
 UseCache                    bool    Yes   Cache suppression factors?          true
 Wcut                        double  no                                        CommonParam[NonResBackground]
+Wcutmin                     double  Yes                                       0
 -->
 
 <alg_conf>
@@ -20,9 +21,10 @@ Wcut                        double  no                                        Co
 
     <param type="string" name="CommonParam"> NonResBackground </param>
 
-    <param type="alg" name="DISModel">   genie::QPMDISPXSec/Default      </param>
+    <param type="alg" name="DISModel">   genie::QPMDISPXSec/Default  </param>
     <param type="alg" name="Hadronizer"> genie::AGKYLowW2019/Default </param>
     <param type="double" name="NRB-EM-XSecScale"> 1. </param>
+    <param type="double" name="Wcutmin"> 0. </param>
   </param_set>
 
 </alg_conf>

--- a/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.cxx
+++ b/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.cxx
@@ -104,7 +104,7 @@ double KNOTunedQPMDISPXSec::DISRESJoinSuppressionFactor(
   double R=0, Ro=0;
 
   double Wmin = kNeutronMass + kPionMass + 1E-3;
-  if( Wmin > fWcutmin ) Wmin = fWcutmin ; 
+  if( Wmin < fWcutmin ) Wmin = fWcutmin ; 
 
   const InitialState & ist = in->InitState();
   const ProcessInfo &  pi  = in->ProcInfo();
@@ -236,7 +236,7 @@ void KNOTunedQPMDISPXSec::LoadConfig(void)
   assert(fHadronizationModel);
 
   GetParam( "Wcut", fWcut ) ;
-  GetParamDefault( "Wcutmin", fWcutmin, 0. ) ;
+  GetParam( "Wcutmin", fWcutmin ) ;
   GetParam( "NRB-EM-XSecScale", fNRBEMScale );
 
   if ( fWcut <= 0. ) {

--- a/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.cxx
+++ b/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.cxx
@@ -103,7 +103,8 @@ double KNOTunedQPMDISPXSec::DISRESJoinSuppressionFactor(
 //
   double R=0, Ro=0;
 
-  const double Wmin = kNeutronMass + kPionMass + 1E-3;
+  double Wmin = kNeutronMass + kPionMass + 1E-3;
+  if( Wmin > fWcutmin ) Wmin = fWcutmin ; 
 
   const InitialState & ist = in->InitState();
   const ProcessInfo &  pi  = in->ProcInfo();
@@ -235,6 +236,7 @@ void KNOTunedQPMDISPXSec::LoadConfig(void)
   assert(fHadronizationModel);
 
   GetParam( "Wcut", fWcut ) ;
+  GetParamDefault( "Wcutmin", fWcutmin, 0. ) ;
   GetParam( "NRB-EM-XSecScale", fNRBEMScale );
 
   if ( fWcut <= 0. ) {

--- a/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.h
+++ b/src/Physics/DeepInelastic/XSection/KNOTunedQPMDISPXSec.h
@@ -56,6 +56,7 @@ private:
 
   bool   fUseCache;         ///< cache reduction factors used in joining scheme
   double fWcut;             ///< apply DIS/RES joining scheme < Wcut
+  double fWcutmin;          ///< Limit to the Non-Resonant background coverage. Below < Wcutmin, only RES is considered
   double fNRBEMScale;       ///< apply NRB EM Scale factor
 };
 


### PR DESCRIPTION
We observed that for some tuned eN RES GV FF, the delta peak is well described without non-res background. We add a new parameter, Wcutmin, to cut the region where we believe non-res background is not necessary. The default is set to 0 to not alter the existing configurations. 

If needed, a new parameter can be used to change the coverage of the non-res bkg in W. 

The example attached considers Wmin of 1.4GeV:
[testNewWmin.pdf](https://github.com/GENIE-MC/Generator/files/13069606/testNewWmin.pdf)

The expected behaviour is observed when using default of 0:
[testnew.pdf](https://github.com/GENIE-MC/Generator/files/13069610/testnew.pdf)