### PR TITLE
add IBD list for VLE tune

### DIFF
--- a/config/EventGeneratorListAssembler.xml
+++ b/config/EventGeneratorListAssembler.xml
@@ -99,6 +99,11 @@ Generator-%d                alg     No
      <param type="alg" name="Generator-0">   genie::EventGenerator/DIS-CC-SINGLEK </param>
   </param_set>
 
+  <param_set name="IBD">
+     <param type="int" name="NGenerators">   1                               </param>
+     <param type="alg" name="Generator-0">   genie::EventGenerator/IBD       </param>
+  </param_set>
+  
   <param_set name="IMD"> 
      <param type="int" name="NGenerators">   2                               </param>
      <param type="alg" name="Generator-0">   genie::EventGenerator/IMD       </param>

--- a/src/Physics/NuclearDeExcitation/NucDeExcitationSim.cxx
+++ b/src/Physics/NuclearDeExcitation/NucDeExcitationSim.cxx
@@ -410,7 +410,7 @@ void NucDeExcitationSim::CarbonTargetSim(GHepRecord * evrec) const
     //>
     double p32Elv = 0.0020;
     //>
-    int ns12 = 8;
+    cont int ns12 = 8;
     double s12Elv[ns12] = {0.0005, 0.0007, 0.0017, 0.0021, 0.0033, 0.0035, 0.0047, 0.0063};
     //double s12Plv[ns12] = {0.21, 0.295, 0.14, 0.26, 0.14, 0.2, 0.03, 0.03};
     // the above multiply by 0.2


### PR DESCRIPTION
 IBD list has been added in config/EventGeneratorListAssembler.xml to select only this channel running the VLE tune

in src/Physics/NuclearDeExcitation/NucDeExcitationSim.cxx line 413, const has been added defining ns12 