### PR TITLE
PROFRW - Move professor2 from reweight to GENIE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/ExternalLibs/professor"]
+	path = src/ExternalLibs/professor
+	url = https://gitlab.com/hepcedar/professor.git

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,16 @@ INITIAL_BUILD_TARGETS = print-make-info \
 		   tools-flux-drivers \
 		   tools-geometry-drivers \
 		   tools-evtlib \
-		   tools-masterclass
+		   tools-masterclass \
+			 lib-professor2-build
 FINAL_BUILD_TARGETS = doxygen-doc \
 		   apps \
 		   install-scripts
 INSTALL_TARGETS =  print-makeinstall-info \
 		   check-previous-installation \
 		   make-install-dirs \
-		   copy-install-files
+		   copy-install-files \
+			 lib-professor2-install
 
 # define targets
 
@@ -236,6 +238,30 @@ ifeq ($(strip $(GOPT_ENABLE_GEOM_DRIVERS)),YES)
 else
 	@echo " "
 	@echo "** Building geometry-drivers was not enabled. Skipping..."
+endif
+
+lib-professor2-build: FORCE
+ifeq ($(strip $(GOPT_WITH_PROFESSOR2)),YES)
+	@echo " "
+	@echo "** Building Professor2..."
+	cd ${GENIE}/src/ExternalLibs/professor && \
+	$(MAKE) lib/libProfessor2.so && \
+	ln -sf ${GENIE}/src/ExternalLibs/professor/lib/libProfessor2.so ${GENIE}/lib/libProfessor2.so && \
+	cd ${GENIE}
+else
+	@echo " "
+	@echo "** Building Professor2 was not enabled. Skipping..."
+endif
+
+lib-professor2-install: FORCE
+ifeq ($(strip $(GOPT_WITH_PROFESSOR2)),YES)
+	@echo " "
+	@echo "** Building Professor2..."
+	cp ${GENIE}/src/ExternalLibs/professor/lib/libProfessor2.so ${GENIE_LIB_INSTALLATION_PATH}
+	cp -r ${GENIE}/src/ExternalLibs/professor/include/Professor ${GENIE_INC_INSTALLATION_PATH}
+else
+	@echo " "
+	@echo "** Building Professor2 was not enabled. Skipping..."
 endif
 
 tools-evtlib: FORCE

--- a/configure
+++ b/configure
@@ -46,6 +46,7 @@ if(($match = grep(/--help/i, @ARGV)) > 0) {
   print "    doxygen-doc          Generate doxygen documentation at build time                default: disabled \n";
   print "    gfortran             Link against external libraries built with gfortran         default: disabled \n";
   print "    g2c                  Link against external libraries built with g77              default: disabled \n";
+  print "    professor2           Build bundled professor2 libraries                          default: disabled \n";
   print "\n options for 3rd party software, prefix with --with- (eg --with-lhapdf5-lib=/some/path/)\n\n";
   print "    compiler          Compiler to use (any of clang,gcc)                          default: gcc \n";
   print "    optimiz-level     Compiler optimization        any of O,O2,O3,OO,Os / default: O2 \n";
@@ -176,6 +177,7 @@ my $gopt_enable_profiler             = "NO";
 my $gopt_enable_doxygen_doc          = "NO";
 my $gopt_enable_gfortran             = "NO";
 my $gopt_enable_g2c                  = "NO";
+my $gopt_enable_professor2           = "NO";
 
 # Check configure's command line arguments for non-default values
 #
@@ -209,6 +211,7 @@ if(($match = grep(/--enable-profiler/i,             @ARGV)) > 0) { $gopt_enable_
 if(($match = grep(/--enable-doxygen-doc/i,          @ARGV)) > 0) { $gopt_enable_doxygen_doc          = "YES"; }
 if(($match = grep(/--enable-gfortran/i,             @ARGV)) > 0) { $gopt_enable_gfortran             = "YES"; }
 if(($match = grep(/--enable-g2c/i,                  @ARGV)) > 0) { $gopt_enable_g2c                  = "YES"; }
+if(($match = grep(/--enable-professor2/i,           @ARGV)) > 0) { $gopt_enable_professor2           = "YES"; }
 
 # LHAPDF6 and LHAPDF5 are mutually exlusive
 if ($gopt_enable_lhapdf6 eq "YES" && $gopt_enable_lhapdf5 eq "YES") {
@@ -949,6 +952,15 @@ if($gopt_enable_g2c eq "YES") {
   }
 }
 
+# ------------------------------------------------
+# Professor2 submode checkout
+# ------------------------------------------------
+if ($gopt_enable_professor2 eq "YES") {
+  #run git submodule update src/ExternalLibs/professor
+  print "Checking out Professor2 submodule...\n";
+  system("git submodule update --init src/ExternalLibs/professor");
+  print "Done.\n"; 
+}
 
 # Save config options
 #
@@ -1006,6 +1018,7 @@ print MKCONF "GOPT_WITH_GEANT4_INC=$gopt_with_geant4_inc\n";
 print MKCONF "GOPT_WITH_GEANT4_LIB=$gopt_with_geant4_lib\n";
 print MKCONF "GOPT_WITH_GFORTRAN_LIB=$gopt_with_gfortran_lib\n";
 print MKCONF "GOPT_WITH_G2C_LIB=$gopt_with_g2c_lib\n";
+print MKCONF "GOPT_WITH_PROFESSOR2=$gopt_enable_professor2\n";
 close(MKCONF);
 
 print "\nYour input configuration options were: @ARGV";

--- a/src/make/Make.include
+++ b/src/make/Make.include
@@ -256,6 +256,13 @@ PYTHIA8_LIBRARIES += -L$(GOPT_WITH_PYTHIA8_LIB) -lpythia8
 endif
 
 #-------------------------------------------------------------------
+# Professor2
+#-------------------------------------------------------------------
+
+PROFESSOR2_INCLUDES = -I$(GENIE)/src/ExternalLibs/professor/include
+PROFESSOR2_LIBRARIES = -L$(GENIE)/src/ExternalLibs/professor/lib -lProfessor2
+
+#-------------------------------------------------------------------
 # ROOT
 #-------------------------------------------------------------------
 # ROOT headers and libraries
@@ -561,7 +568,8 @@ CPP_INCLUDES := \
     $(LHAPDF_INCLUDES) \
     $(APFEL_INCLUDES) \
     $(GSL_INCLUDES) \
-    $(GENIE_INCLUDES)
+    $(GENIE_INCLUDES) \
+    $(PROFESSOR2_INCLUDES)
 
 ROOT_DICT_GEN_INCLUDES := \
     $(LINUX_SYS_INCLUDES) \


### PR DESCRIPTION
Professor2 is not yet used directly inside Generator itself, but this
will be useful for the WIP reweight update. Since both comparison
and reweight package is going to be linked to  professor2. We are
putting professor2 as external code for GENIE.

The version selected is professor-2.4.1. The design of submodule 
system only allow specifying branch or commit. 

Checking out of submodules will be done automatically when 
user call `configure` with `--enable-professor2`.

