### PR TITLE
Use Singleton Messenger

### DIFF
--- a/src/Framework/Messenger/Messenger.h
+++ b/src/Framework/Messenger/Messenger.h
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <cstring>
 #include <string>
+#include <mutex>
 #include <map>
 
 // ROOT5 has difficulty with parsing log4cpp headers
@@ -267,25 +268,13 @@ public:
 
 private:
   Messenger();
-  Messenger(const Messenger & config_pool);
+  Messenger(const Messenger &) = delete;
+  Messenger(Messenger&&) = delete;
   virtual ~Messenger();
-
-  static Messenger * fInstance;
 
   void Configure(void);
 
   log4cpp::Priority::Value PriorityFromString(string priority);
-
-  struct Cleaner {
-      void DummyMethodAndSilentCompiler() { }
-      ~Cleaner() {
-         if (Messenger::fInstance !=0) {
-            delete Messenger::fInstance;
-            Messenger::fInstance = 0;
-         }
-      }
-  };
-  friend struct Cleaner;
 };
 
 }      // genie namespace


### PR DESCRIPTION
Previous implementation of Messenger will deconstruct before some class that are using this in its deconstructor. This will lead to noisy output and a sigsgev error. 

This should fix it and always make sure Messenger is deconstructed at correctly order.