### PR TITLE
Provides ways to load Reweight configurations from AlgConfigPool

### DIFF
--- a/src/Framework/Algorithm/AlgConfigPool.h
+++ b/src/Framework/Algorithm/AlgConfigPool.h
@@ -66,7 +66,8 @@ private:
   string BuildConfigKey      (string alg_name, string param_set) const;
   string BuildConfigKey      (const Algorithm * algorithm) const;
   bool   LoadAlgConfig       (void);
-  bool   LoadMasterConfig    (void);
+  bool   LoadMasterConfig    (std::string configname);
+  bool   LoadMasterConfigs   (void);
   bool   LoadGlobalParamLists(void);
   bool   LoadCommonLists( const string & file_id );
   bool   LoadTuneGeneratorList(void);

--- a/src/Framework/Utils/XmlParserUtils.cxx
+++ b/src/Framework/Utils/XmlParserUtils.cxx
@@ -87,8 +87,10 @@ string genie::utils::xml::GetXMLPathList( bool add_tune )   {
   }  // requested tune and there is a tune
 
   pathlist += GetXMLDefaultPath() ;  // standard path in case no env
+  std::string GENIE_REWEIGHT = std::getenv( "GENIE_REWEIGHT" );
+  if (!GENIE_REWEIGHT.empty())
+    pathlist += ":" + (GENIE_REWEIGHT + "/config") ;
   pathlist += ":$GENIE/src/Tools/Flux/GNuMINtuple";  // special case
-
   return pathlist;
 }
 


### PR DESCRIPTION
Currently `AlgConfigPool` will only load configuration from `GENIE/config`. While we are planning to make some components from reweight become configurable with  `AlgConfigPool`. This requires some modifications to current  `AlgConfigPool` and related code:

 - Don't early return when failed to load tunning information
 - Try to load `reweight_master_config.xml` in addition to `master_config.xml`
 - Add `GENIE_REWEIGHT/config` to search dirs for confiurations
