### PR TITLE
configure: change detection of Root MathMore

### DIFF
--- a/configure
+++ b/configure
@@ -105,9 +105,9 @@ unless defined $ROOTSYS;
 # (GENIE uses GSL via ROOT's MathMore library.)
 #
 {
-  $mathmore_lib = "$ROOTSYS/lib/libMathMore.so";
-  if( ! -f $mathmore_lib ) {
-     die ("*** Error *** ROOT needs to be built with GSL/MathMore enabled.");
+  chomp($has_mathmore = `root-config --has-mathmore`);
+  if ( $has_mathmore ne 'yes' ) {
+    die ("*** Error *** ROOT needs to be built with GSL/MathMore enabled.");
   }
 }
 


### PR DESCRIPTION
I'm working on a system (a Mac M1 with Root installed using the [Spack](https://spack.io) package manager) where the Root libraries are installed under `$ROOTSYS/lib/root`, not `$ROOTSYS/lib` so the original detection of whether or not Root was compiled with mathmore is not working. 

I'm proposing here a fix based on the `root-config` executable instead.  