### PR TITLE
Addressing the error reported by Julia: Floating point invalid operation

### DIFF
--- a/src/Physics/HadronTensors/TabulatedLabFrameHadronTensor.cxx
+++ b/src/Physics/HadronTensors/TabulatedLabFrameHadronTensor.cxx
@@ -433,14 +433,14 @@ double genie::TabulatedLabFrameHadronTensor::dSigma_dT_dCosTheta_rosenbluth(int 
     //   genie::constants::kAem / (2. * E_probe * s2_half), 2) * c2_half;
     // the previous expression was an approximation in the case of ml-->0 (UR limit).
     // To be more accurate, SIGMA_MOTT SHOULD BE EXPRESSED AS:
-    double mott = std::pow(2.*El*genie::constants::kAem / q2, 2) * c2_half;
+    double mott = std::pow(2.*El*genie::constants::kAem / q2, 2);
     // ALTHOUGH THE DIFFERENCES SHOULD BE VERY SMALL OR NEGLIGIBLE
 
     // Longitudinal part
-    double l_part = std::pow(q2 / q_mag2, 2) * entry.W00;
+    double l_part = std::pow(q2 / q_mag2, 2) * entry.W00 * c2_half;
 
     // Transverse part
-    double t_part = ( (2.*s2_half / c2_half) - (q2 / q_mag2) ) * entry.Wxx;
+    double t_part = ( 2.*s2_half - (q2*c2_half / q_mag2) ) * entry.Wxx;
 
     // This is the double diff cross section dsigma/dOmega/domega==dsigma/dOmega/dEl
 

--- a/src/Physics/Multinucleon/XSection/MECUtils.cxx
+++ b/src/Physics/Multinucleon/XSection/MECUtils.cxx
@@ -400,7 +400,7 @@ double genie::utils::mec::GetMaxXSecTlctl( const XSecAlgorithmI& xsec_model,
         double plep = std::sqrt( std::max(0., std::pow(T + LepMass, 2)
           - LepMass*LepMass) );
 
-        double Costh = ( 2.*Enu*Elep - ProbeMass*ProbeMass - LepMass*LepMass
+        double Costh = plep==0?0:( 2.*Enu*Elep - ProbeMass*ProbeMass - LepMass*LepMass
           - Q2 ) / ( 2. * pnu * plep );
         // Respect the bounds of the cosine function.
         Costh = std::min( std::max(-1., Costh), 1. );


### PR DESCRIPTION
Julia has running e-Carbon events using GEM21_11c. When running with this mode, I fail to generate events at low Q2 (0.1-0.4) at 1GeV.
She get the error:
```
Copying 716538 bytes https://fndcadoor.fnal.gov:2880/genie/persistent/users/jtenavid/e4nu_files/GENIE_Files/2024Splines/GEM21_11c_Dipole_Q2_01_eNuclei.xml => file:///srv/no_xfer/0/TRANSFERRED_INPUT_FILES/GEM21_11c_Dipole_Q2_01_eNuclei.xml
ERROR - Floating point invalid operation.
./e_on_1000060120_1161MeV_48.sh: line 10: 18838 Floating point exception(core dumped) gevgen -p 11 -n 400000 -e 1.161 -t 1000060120 -r 11100006012048 --seed 1210981197 --cross-sections \$CONDOR_DIR_INPUT/GEM21_11c_Dipole_Q2_01_eNuclei.xml --event-generator-list EM --tune GEM21_11c_00_000 -o e_on_1000060120_1161MeV_48.ghep.root --message-thresholds $CONDOR_DIR_INPUT/conf/Messenger.xml
```
This PR fix this error and another induced one.