### PR TITLE
Add a Configuration of matrix in Genie

### DIFF
--- a/data/example/matrix/testmat.dat
+++ b/data/example/matrix/testmat.dat
@@ -1,0 +1,6 @@
+% a matrix with 2 columns and 5 rows
+1.0 1.1
+2.0 2.1
+2.0 2.1
+2.0 2.1
+1.0 5.3

--- a/src/Framework/Algorithm/AlgConfigPool.cxx
+++ b/src/Framework/Algorithm/AlgConfigPool.cxx
@@ -509,7 +509,11 @@ int  AlgConfigPool::AddParameterMatrix  (Registry * r, string pt, string pn, str
   // Each entry will be named pn+"-i"+"-j" where i and j are 
   // index of row and column and replaced by the number
 
-  std::ifstream file(pv);
+  char * GENIE_PATH = std::getenv("GENIE");
+  string filepath = std::string(GENIE_PATH) + "/" + pv;
+  std::cout << filepath << std::endl;
+
+  std::ifstream file(filepath);
   if (!file.is_open()) {
     throw std::runtime_error("Could not open file");
   }
@@ -517,6 +521,11 @@ int  AlgConfigPool::AddParameterMatrix  (Registry * r, string pt, string pn, str
   int n_row = 0, n_col = 0;
   int i_row = 0;
   while (getline(file, line)) {
+    size_t start = line.find_first_not_of(" \t");
+    std::string trimmedLine = (start == std::string::npos) ? "" : line.substr(start);
+    if(trimmedLine.empty()) continue;
+    if(!trimmedLine.empty() && trimmedLine[0] == '%') continue;
+
     std::istringstream iss(line);
     double value;
     int i_col = 0;

--- a/src/Framework/Algorithm/AlgConfigPool.cxx
+++ b/src/Framework/Algorithm/AlgConfigPool.cxx
@@ -511,12 +511,11 @@ int  AlgConfigPool::AddParameterMatrix  (Registry * r, string pt, string pn, str
 
   char * GENIE_PATH = std::getenv("GENIE");
   string filepath = std::string(GENIE_PATH) + "/" + pv;
-  std::cout << filepath << std::endl;
-
   std::ifstream file(filepath);
   if (!file.is_open()) {
     throw std::runtime_error("Could not open file");
   }
+
   std::string line;
   int n_row = 0, n_col = 0;
   int i_row = 0;

--- a/src/Framework/Algorithm/AlgConfigPool.cxx
+++ b/src/Framework/Algorithm/AlgConfigPool.cxx
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdlib>
+#include <fstream>
 
 #include "libxml/xmlmemory.h"
 #include "libxml/parser.h"
@@ -363,6 +364,19 @@ bool AlgConfigPool::LoadRegistries(
 
 	      this -> AddParameterVector( config, param_type, param_name, param_value, delim ) ;
 	    }
+            else if (param_type.find( "mat-" ) == 0) {
+              param_type = param_type.substr( 4 ) ;
+              LOG("AlgConfigPool", pNOTICE) << "Liang Liu" << param_type ;
+                string importfile = utils::str::TrimSpaces( utils::xml::GetAttribute(xml_param, "importfile"));
+                if(!importfile.compare("false")){
+                  string rowdelim = utils::str::TrimSpaces( utils::xml::GetAttribute(xml_param, "rowdelim"));
+                  string coldelim = utils::str::TrimSpaces( utils::xml::GetAttribute(xml_param, "coldelim"));
+                  this -> AddParameterMatrix(config, param_type, param_name, param_value, importfile, rowdelim, coldelim);
+                }
+                else if(!importfile.compare("true")){
+                  this -> AddParameterMatrix(config, param_type, param_name, param_value, importfile);
+                }
+            }
 	    else this->AddConfigParameter( config,
 					   param_type, param_name,
 					   param_value);
@@ -422,6 +436,109 @@ int  AlgConfigPool::AddParameterVector  (Registry * r, string pt, string pn, str
   return bits.size() ;
 
 }
+
+//____________________________________________________________________________
+int  AlgConfigPool::AddParameterMatrix  (Registry * r, string pt, string pn, string pv, const string & importfile,
+					 const string & rowdelim, const string & coldelim ) {
+
+  // Adds a configuration parameter vector
+  // It is simply add a number of entries in the Registy
+  // The name scheme starts from the name and it goes like
+  // 'N'+pn+'s' that will be an integer with the number of entries.
+  // Each entry will be named pn+"-i" where i is replaced by the number
+
+  if(!importfile.compare("false")){
+    if(!rowdelim.compare(coldelim) || rowdelim.empty() || coldelim.empty()) {
+      LOG("AlgConfigPool", pFATAL) << "row and column have wrong delims: " << rowdelim << "  " << coldelim ;
+      exit(1);
+    }
+    SLOG("AlgConfigPool", pDEBUG)
+      << "Adding Parameter Matrix [" << pt << "]: Key = "
+      << pn << " -> Value = " << pv;
+
+    vector<string> mat_row = utils::str::Split( pv, rowdelim ) ;
+
+    string r_name = Algorithm::BuildParamMatRowSizeKey( pn ) ;
+
+
+    unsigned int n_row = 0, n_col = 0;
+    std::stringstream r_value ;
+    r_value << mat_row.size() ;
+    n_row = mat_row.size() ;
+
+    this->AddConfigParameter(r, "int", r_name, r_value.str() );
+
+    for ( unsigned int i = 0 ; i < mat_row.size() ; ++i ) {
+      vector<string> bits = utils::str::Split( mat_row[i], coldelim ) ;
+      if(i == 0){
+        string c_name = Algorithm::BuildParamMatColSizeKey( pn ) ;
+        std::stringstream c_value ;
+        c_value << bits.size();
+        n_col = bits.size();
+        this->AddConfigParameter(r, "int", c_name, c_value.str() );
+      }
+      else{
+        if(n_col != bits.size()){
+          LOG("AlgConfigPool", pFATAL) << "wrong size of matrix in row: " << i;
+          exit(1);
+        }
+      }
+
+      for ( unsigned int j = 0 ; j < bits.size() ; ++j ) {
+
+        std::string name = Algorithm::BuildParamMatKey( pn, i, j ) ;
+
+        this -> AddConfigParameter( r, pt, name, utils::str::TrimSpaces( bits[j] ) );
+
+      }
+    }
+    return n_row * n_col;
+  }
+  else if(!importfile.compare("true")){
+    std::ifstream file(pv);
+    if (!file.is_open()) {
+      throw std::runtime_error("Could not open file");
+    }
+    std::string line;
+    int n_row = 0, n_col = 0;
+    int i_row = 0;
+    while (getline(file, line)) {
+      std::istringstream iss(line);
+      double value;
+      int i_col = 0;
+      while (iss >> value) {
+        std::string name = Algorithm::BuildParamMatKey( pn, i_row, i_col ) ;
+        this -> AddConfigParameter( r, pt, name, utils::str::TrimSpaces( std::to_string(value) ) );
+        i_col++;
+      }
+      if(i_row == 0)
+        n_col = i_col;
+      else{
+        if(n_col != i_col){
+           LOG("AlgConfigPool", pFATAL) << "wrong size of matrix in row: " << i_row;
+           exit(1);
+        }
+      }
+      i_row++;
+    }
+    n_row = i_row;
+    std::stringstream r_value ;
+    r_value << n_row ;
+    string r_name = Algorithm::BuildParamMatRowSizeKey( pn ) ;
+    this->AddConfigParameter(r, "int", r_name, r_value.str() );
+    std::stringstream c_value ;
+    c_value << n_col ;
+    string c_name = Algorithm::BuildParamMatColSizeKey( pn ) ;
+    this->AddConfigParameter(r, "int", c_name, c_value.str() );
+    return n_row*n_col;
+  }
+  else{
+    LOG("AlgConfigPool", pFATAL) << "wrong input of matrix! ";
+    exit(1);
+  }
+}
+
+
 
 //____________________________________________________________________________
 void AlgConfigPool::AddConfigParameter( Registry * r,

--- a/src/Framework/Algorithm/AlgConfigPool.h
+++ b/src/Framework/Algorithm/AlgConfigPool.h
@@ -74,7 +74,8 @@ private:
   bool   LoadSingleAlgConfig (string alg_name, string file_name);
   bool   LoadRegistries      (string key_base, string file_name, string root);
   int    AddParameterVector  (Registry * r, string pt, string pn, string pv, const string & delim = ";" );
-  int    AddParameterMatrix  (Registry * r, string pt, string pn, string pv, const string & importfile, const string & rowdelim = ";", const string & coldelim = "," );
+  int    AddParameterMatrix  (Registry * r, string pt, string pn, string pv, const string & rowdelim, const string & coldelim );
+  int    AddParameterMatrix  (Registry * r, string pt, string pn, string pv);
   void   AddConfigParameter  (Registry * r, string pt, string pn, string pv);
   void   AddBasicParameter   (Registry * r, string pt, string pn, string pv);
   void   AddRootObjParameter (Registry * r, string pt, string pn, string pv);

--- a/src/Framework/Algorithm/AlgConfigPool.h
+++ b/src/Framework/Algorithm/AlgConfigPool.h
@@ -74,6 +74,7 @@ private:
   bool   LoadSingleAlgConfig (string alg_name, string file_name);
   bool   LoadRegistries      (string key_base, string file_name, string root);
   int    AddParameterVector  (Registry * r, string pt, string pn, string pv, const string & delim = ";" );
+  int    AddParameterMatrix  (Registry * r, string pt, string pn, string pv, const string & importfile, const string & rowdelim = ";", const string & coldelim = "," );
   void   AddConfigParameter  (Registry * r, string pt, string pn, string pv);
   void   AddBasicParameter   (Registry * r, string pt, string pn, string pv);
   void   AddRootObjParameter (Registry * r, string pt, string pn, string pv);

--- a/src/Framework/Algorithm/Algorithm.cxx
+++ b/src/Framework/Algorithm/Algorithm.cxx
@@ -522,6 +522,33 @@ string  Algorithm::BuildParamVectSizeKey( const std::string & comm_name ) {
   return 'N' + comm_name + 's' ;
 
 }
+//____________________________________________________________________________
+
+string  Algorithm::BuildParamMatKey( const std::string & comm_name, unsigned int i, unsigned int j ) {
+
+  std::stringstream name;
+  name << comm_name << '-' << i << "-" << j ;
+  return name.str() ;
+
+}
+
+//____________________________________________________________________________
+
+string  Algorithm::BuildParamMatRowSizeKey( const std::string & comm_name ) {
+
+  return "Nrow" + comm_name + 's' ;
+
+}
+
+//____________________________________________________________________________
+
+string  Algorithm::BuildParamMatColSizeKey( const std::string & comm_name ) {
+
+  return "Ncol" + comm_name + 's' ;
+
+}
+
+
 
 //____________________________________________________________________________
 
@@ -552,6 +579,40 @@ int  Algorithm::GetParamVectKeys( const std::string & comm_name, std::vector<RgK
 
   return k.size() ;
 }
+
+//____________________________________________________________________________
+
+int  Algorithm::GetParamMatKeys( const std::string & comm_name, std::vector<RgKey> & k,
+				  bool is_top_call ) const {
+
+  k.clear() ;
+
+  int n_row = 0, n_col = 0 ;
+  std::string row_name = Algorithm::BuildParamMatRowSizeKey( comm_name ) ;
+  std::string col_name = Algorithm::BuildParamMatColSizeKey( comm_name ) ;
+
+  bool found = GetParam( row_name, n_row, is_top_call ) && GetParam( col_name, n_col, is_top_call ) ;
+
+  if ( ! found ) {
+    return 0 ;
+  }
+
+  for ( int i = 0; i < n_row; ++i ) {
+    for ( int j = 0; j < n_col; ++j ) {
+
+      RgKey temp_key = Algorithm::BuildParamMatKey( comm_name, i, j ) ;
+
+      // potentially, if it is a top call,
+      // we might want to check if the key actually exist in the global Registry
+      // Not a priority irght now
+
+      k.push_back( temp_key ) ;
+    }
+  }
+
+  return k.size() ;
+}
+
 
 
 //____________________________________________________________________________

--- a/src/Framework/Algorithm/Algorithm.h
+++ b/src/Framework/Algorithm/Algorithm.h
@@ -198,6 +198,9 @@ protected:
   template<class T>
     int GetParamMat( const std::string & comm_name, TMatrixT<T> & mat,
 		      bool is_top_call = true ) const ;
+  template<class T>
+    int GetParamMatSym( const std::string & comm_name, TMatrixTSym<T> & mat,
+		      bool is_top_call = true ) const ;
 
   int GetParamMatKeys( const std::string & comm_name, std::vector<RgKey> & k,
 			bool is_top_call = true ) const ;

--- a/src/Framework/Algorithm/Algorithm.h
+++ b/src/Framework/Algorithm/Algorithm.h
@@ -34,6 +34,7 @@
 #include "Framework/Registry/Registry.h"
 #include "Framework/Registry/RegistryItemTypeDef.h"
 #include "Framework/Messenger/Messenger.h"
+#include "TMatrixT.h"
 
 using std::string;
 using std::ostream;
@@ -138,6 +139,11 @@ public:
   static string BuildParamVectKey( const std::string & comm_name, unsigned int i ) ;
   static string BuildParamVectSizeKey( const std::string & comm_name ) ;
 
+  static string BuildParamMatKey( const std::string & comm_name, unsigned int i, unsigned int j) ;
+  static string BuildParamMatRowSizeKey( const std::string & comm_name ) ;
+  static string BuildParamMatColSizeKey( const std::string & comm_name ) ;
+
+
 protected:
   Algorithm();
   Algorithm(string name);
@@ -187,6 +193,15 @@ protected:
 
   int GetParamVectKeys( const std::string & comm_name, std::vector<RgKey> & k,
 			bool is_top_call = true ) const ;
+
+  //! Handle to load matrix of parameters
+  template<class T>
+    int GetParamMat( const std::string & comm_name, TMatrixT<T> & mat,
+		      bool is_top_call = true ) const ;
+
+  int GetParamMatKeys( const std::string & comm_name, std::vector<RgKey> & k,
+			bool is_top_call = true ) const ;
+
 
   int   AddTopRegistry( Registry * rp, bool owns = true );  ///< add registry with top priority, also update ownership
   int   AddLowRegistry( Registry * rp, bool owns = true );  ///< add registry with lowest priority, also update ownership

--- a/src/Framework/Algorithm/Algorithm.icc
+++ b/src/Framework/Algorithm/Algorithm.icc
@@ -150,4 +150,31 @@ template<class T>
     return v.size() ;    		            
 }
 
- 
+//add the the template specification as in Registry for RegistryItemI?
+
+template<class T>
+  int genie::Algorithm::GetParamMat( const std::string & comm_name, TMatrixT<T> & mat,
+                                         bool is_top_call ) const {
+    
+
+    mat.Clear() ; 
+
+    int n_row = 0, n_col = 0;
+    std::string row_name = Algorithm::BuildParamMatRowSizeKey( comm_name ) ; 
+    std::string col_name = Algorithm::BuildParamMatColSizeKey( comm_name ) ; 
+    		
+    bool found = GetParam( row_name, n_row, is_top_call ) && GetParam( col_name, n_col, is_top_call ) ;
+    if ( ! found ) return 0  ;
+
+    mat.ResizeTo( n_row, n_col ) ;
+
+    for ( int i = 0; i < n_row; ++i ) {
+      for ( int j = 0; j < n_col; ++j ) {
+  	RgKey temp_key = Algorithm::BuildParamMatKey( comm_name, i,  j ) ; 
+  	found = GetParam( temp_key, mat[i][j], is_top_call ) ; 
+      }
+    }
+
+    return n_row*n_col;    		            
+}
+

--- a/src/Framework/Algorithm/Algorithm.icc
+++ b/src/Framework/Algorithm/Algorithm.icc
@@ -155,14 +155,12 @@ template<class T>
 template<class T>
   int genie::Algorithm::GetParamMat( const std::string & comm_name, TMatrixT<T> & mat,
                                          bool is_top_call ) const {
-    
 
-    mat.Clear() ; 
+    mat.Clear() ;
 
     int n_row = 0, n_col = 0;
-    std::string row_name = Algorithm::BuildParamMatRowSizeKey( comm_name ) ; 
-    std::string col_name = Algorithm::BuildParamMatColSizeKey( comm_name ) ; 
-    		
+    std::string row_name = Algorithm::BuildParamMatRowSizeKey( comm_name ) ;
+    std::string col_name = Algorithm::BuildParamMatColSizeKey( comm_name ) ;
     bool found = GetParam( row_name, n_row, is_top_call ) && GetParam( col_name, n_col, is_top_call ) ;
     if ( ! found ) return 0  ;
 
@@ -170,11 +168,11 @@ template<class T>
 
     for ( int i = 0; i < n_row; ++i ) {
       for ( int j = 0; j < n_col; ++j ) {
-  	RgKey temp_key = Algorithm::BuildParamMatKey( comm_name, i,  j ) ; 
-  	found = GetParam( temp_key, mat[i][j], is_top_call ) ; 
+  	RgKey temp_key = Algorithm::BuildParamMatKey( comm_name, i,  j ) ;
+  	found = GetParam( temp_key, mat[i][j], is_top_call ) ;
       }
     }
 
-    return n_row*n_col;    		            
+    return n_row*n_col;
 }
 

--- a/src/Framework/Algorithm/Algorithm.icc
+++ b/src/Framework/Algorithm/Algorithm.icc
@@ -176,3 +176,30 @@ template<class T>
     return n_row*n_col;
 }
 
+template<class T>
+  int genie::Algorithm::GetParamMatSym( const std::string & comm_name, TMatrixTSym<T> & mat,
+                                         bool is_top_call ) const {
+
+    mat.Clear() ;
+
+    int n_row = 0, n_col = 0;
+    std::string row_name = Algorithm::BuildParamMatRowSizeKey( comm_name ) ;
+    std::string col_name = Algorithm::BuildParamMatColSizeKey( comm_name ) ;
+    bool found = GetParam( row_name, n_row, is_top_call ) && GetParam( col_name, n_col, is_top_call ) ;
+    if ( ! found ) return 0  ;
+    if (n_row != n_col) return 0;
+
+    // only using n_row to set the symmetry matrix
+
+    mat.ResizeTo( n_row, n_row ) ;
+
+    for ( int i = 0; i < n_row; ++i ) {
+      for ( int j = 0; j < n_row; ++j ) {
+  	RgKey temp_key = Algorithm::BuildParamMatKey( comm_name, i,  j ) ;
+  	found = GetParam( temp_key, mat[i][j], is_top_call ) ;
+      }
+    }
+
+    return n_row*n_row;
+}
+


### PR DESCRIPTION
Since a covariance matrix is needed when I implement the reweight method for Z expansion vector form factor model. Here is a solution to import the covariance matrix from xml configuration.  Covariance matrix can be imported from xml directly or from a plain text file. There are two example:

` <param type="mat-double" name="CCTEST0@CovarianceMatrix" importfile="false" rowdelim=";" coldelim=","> 2.0, 1.0, 2; 1.1, 2.1, 2; 1.1, 2.1, 2; 1.1, 2.1, 3.2 </param>`
   `<param type="mat-double" name="CCTEST1@CovarianceMatrix" importfile="true"> /exp/uboone/app/users/liangliu/Genie/genie/Reweight/data/testmat.dat  </param>`
   
The matrix can be get by [GetParamMat()](https://github.com/LiangLiu212/Generator/blob/f5b1e0aed0fa88b623bb3f6c285f9a9a6dcd2d32/src/Framework/Algorithm/Algorithm.h#L197C1-L203C37)