### PR TITLE
Workaround a memory leak with old ROOT IO

### DIFF
--- a/src/Framework/Ntuple/LinkDef.h
+++ b/src/Framework/Ntuple/LinkDef.h
@@ -12,7 +12,7 @@
 #pragma link C++ class genie::NtpMCJobConfig;
 #pragma link C++ class genie::NtpMCRecHeader;
 #pragma link C++ class genie::NtpMCRecordI;
-#pragma link C++ class genie::NtpMCEventRecord;
+#pragma link C++ class genie::NtpMCEventRecord-;
 #pragma link C++ class genie::NtpWriter;
 
 #endif

--- a/src/Framework/Ntuple/NtpMCEventRecord.cxx
+++ b/src/Framework/Ntuple/NtpMCEventRecord.cxx
@@ -10,6 +10,7 @@
 
 #include "Framework/EventGen/EventRecord.h"
 #include "Framework/Messenger/Messenger.h"
+#include "TBuffer.h"
 #include "Framework/Ntuple/NtpMCEventRecord.h"
 
 using std::endl;
@@ -75,3 +76,29 @@ void NtpMCEventRecord::Clear(Option_t * /*opt*/)
   this->hdr.ievent = 0;
 }
 //____________________________________________________________________________
+
+// Extracted from the code ROOT generated
+// added check-and-delete before streaming to
+// avoid memory leak
+void NtpMCEventRecord::Streamer(TBuffer &R__b) {
+  // Stream an object of class genie::NtpMCEventRecord.
+
+  UInt_t R__s, R__c;
+  if (R__b.IsReading()) {
+    Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+    if (R__v) {
+    }
+    genie::NtpMCRecordI::Streamer(R__b);
+    if (event) {
+      delete event;
+      event = nullptr;
+    }
+    R__b >> event;
+    R__b.CheckByteCount(R__s, R__c, ::genie::NtpMCEventRecord::IsA());
+  } else {
+    R__c = R__b.WriteVersion(::genie::NtpMCEventRecord::IsA(), kTRUE);
+    genie::NtpMCRecordI::Streamer(R__b);
+    R__b << event;
+    R__b.SetByteCount(R__c, kTRUE);
+  }
+}


### PR DESCRIPTION
This is related to a [long existing bug in ROOT](https://github.com/root-project/root/issues/16375), with related workaround in GENIE traced back to [this commit from Apr 2006](https://github.com/GENIE-MC/Generator/commit/64b7b4b759803785202961211342ff1295c98bae). But such workaround by manually calling the `Clean` method after each entry of event being processed is not possible with working with the latest ROOT's RDataFrame analysis framework like I did [in the reweighting testing code](https://github.com/karuboniru/Reweight/blob/professor_reweight/src/Apps/gRwProfTest.cxx).

The bug is that a class is being read from a ROOT file and: 
 - the class contains a pointer to another object
 - the root dict for the class is generated without a "+" in `#pragma link C++ class ClassName+;`.

Since the bug is related to the old IO implementation in ROOT they are not going to fix it. But there are 2 approaches to fix or workaround this:
 1. move to new IO implementation, always specify "+" in `LinkDef.h`
 2. Use user defined `Streamer` to free the memory before the pointer is overwritten by TBuffer.

The first one seemd to be feasible, but the fatal issue is that the old and new IO don't compatible. The root file generated with new IO method won't be recognized by old dictionaty and vice versa. Developers from ROOT [did provide an example](https://github.com/karuboniru/root_memory_leak_report/pull/1/files) to show how to partially workaround the incompatibility with the version number tricks to keep old files readable, but it would still break the compatibility from the other side.

So this PR is the conservative approach, the second one, the IO and file format is kept the same. This should not be breaking anything, the only difficulty it would introduce is when we change the defination of `NtpMCEventRecord` we would have to update the definition of `NtpMCEventRecord::Streamer` here accordingly. (But at that time we can really move to the new IO from ROOT since change the definition of a class will introduce incompatibility)