### PR TITLE
Fix some obvious memory leak

### DIFF
--- a/src/Framework/Algorithm/AlgConfigPool.cxx
+++ b/src/Framework/Algorithm/AlgConfigPool.cxx
@@ -193,7 +193,7 @@ bool AlgConfigPool::LoadMasterConfig(std::string configname)
 
        string alg_name  = utils::str::TrimSpaces(
                      utils::xml::GetAttribute(xml_ac, "alg"));
-       string config_file = utils::xml::TrimSpaces(
+       string config_file = utils::xml::TrimSpacesClean(
                 xmlNodeListGetString(xml_doc, xml_ac->xmlChildrenNode, 1));
 
        pair<string, string> alg_conf(alg_name, config_file);
@@ -351,7 +351,7 @@ bool AlgConfigPool::LoadRegistries(
                    utils::str::TrimSpaces(
                        utils::xml::GetAttribute(xml_param, "name"));
             string param_value =
-                    utils::xml::TrimSpaces(
+                    utils::xml::TrimSpacesClean(
                                xmlNodeListGetString(
                                  xml_doc, xml_param->xmlChildrenNode, 1));
 

--- a/src/Framework/EventGen/GMCJDriver.cxx
+++ b/src/Framework/EventGen/GMCJDriver.cxx
@@ -781,7 +781,7 @@ void GMCJDriver::ComputeProbScales(void)
     fPmax.insert(map<int,TH1D*>::value_type(neutrino_pdgc,pmax_hst));
   } // nu
 
-  delete ebins;
+  delete[] ebins;
 
   // Compute global probability scale
   // Sum Probabilities {

--- a/src/Framework/EventGen/PathLengthList.cxx
+++ b/src/Framework/EventGen/PathLengthList.cxx
@@ -238,7 +238,7 @@ XmlParserStatus_t PathLengthList::LoadFromXml(string filename)
        string spdgc = utils::str::TrimSpaces(
                          utils::xml::GetAttribute(xmlCur, "pdgc"));
 
-       string spl = utils::xml::TrimSpaces(
+       string spl = utils::xml::TrimSpacesClean(
                            xmlNodeListGetString(xml_doc, xmlPlVal, 1));
 
        LOG("PathL", pDEBUG) << "pdgc = " << spdgc << " --> pl = " << spl;

--- a/src/Framework/Messenger/Messenger.cxx
+++ b/src/Framework/Messenger/Messenger.cxx
@@ -170,7 +170,7 @@ bool Messenger::SetPrioritiesFromXmlFile(string filenames)
          string msgstream = utils::str::TrimSpaces(
                   utils::xml::GetAttribute(xml_msgp, "msgstream"));
          string priority =
-                utils::xml::TrimSpaces( xmlNodeListGetString(
+                utils::xml::TrimSpacesClean( xmlNodeListGetString(
                                xml_doc, xml_msgp->xmlChildrenNode, 1));
          log4cpp::Priority::Value pv = this->PriorityFromString(priority);
          this->SetPriorityLevel(msgstream.c_str(), pv);

--- a/src/Framework/Ntuple/NtpWriter.cxx
+++ b/src/Framework/Ntuple/NtpWriter.cxx
@@ -51,7 +51,7 @@ fNtpMCTreeHeader(0)
 //____________________________________________________________________________
 NtpWriter::~NtpWriter()
 {
-
+  delete fNtpMCTreeHeader;
 }
 //____________________________________________________________________________
 void NtpWriter::AddEventRecord(int ievent, const EventRecord * ev_rec)

--- a/src/Framework/Numerical/Spline.cxx
+++ b/src/Framework/Numerical/Spline.cxx
@@ -213,7 +213,7 @@ bool Spline::LoadFromXmlFile(string filename, string xtag, string ytag)
            bool is_ytag = ! xmlStrcmp(tag,(const xmlChar *) ytag.c_str());
            if (is_xtag || is_ytag) {
               xmlNodePtr xmlValTagChild = xmlKnotChild->xmlChildrenNode;
-              string val = utils::xml::TrimSpaces(
+              string val = utils::xml::TrimSpacesClean(
                          xmlNodeListGetString(xml_doc, xmlValTagChild, 1));
 
               if (is_xtag) vx[iknot] = atof(val.c_str());

--- a/src/Framework/Utils/XmlParserUtils.cxx
+++ b/src/Framework/Utils/XmlParserUtils.cxx
@@ -21,6 +21,7 @@
 
 #include "Framework/Utils/StringUtils.h"
 #include "Framework/Utils/RunOpt.h"
+#include "libxml/xmlmemory.h"
 
 
 using std::ostringstream;
@@ -38,6 +39,13 @@ string genie::utils::xml::TrimSpaces(xmlChar * xmls) {
 
   string str = string( (const char *) xmls );
   return utils::str::TrimSpaces(str);
+}
+
+string genie::utils::xml::TrimSpacesClean(xmlChar *xmls) {
+  // Does the same work as TrimSpaces, and cleans up the xmlChar memory
+  string str = TrimSpaces(xmls);
+  xmlFree(xmls);
+  return str;
 }
 
 //_________________________________________________________________________
@@ -166,7 +174,7 @@ bool genie::utils::xml::GetBool(xmlDocPtr xml_doc, string node_path)
   if(node==NULL) {
     return false;
   }
-  string content = genie::utils::xml::TrimSpaces(
+  string content = genie::utils::xml::TrimSpacesClean(
       xmlNodeListGetString(xml_doc, node->xmlChildrenNode, 1) );
 
   if(content == "true" ||
@@ -199,7 +207,7 @@ int genie::utils::xml::GetInt(xmlDocPtr xml_doc, string node_path)
   if(node==NULL) {
     return -999999;
   }
-  string content = genie::utils::xml::TrimSpaces(
+  string content = genie::utils::xml::TrimSpacesClean(
       xmlNodeListGetString(xml_doc, node->xmlChildrenNode, 1) );
   int value = atoi(content.c_str());
   return value;
@@ -214,7 +222,7 @@ vector<int> genie::utils::xml::GetIntArray(xmlDocPtr xml_doc, string node_path)
     return array;
   }
 
-  string content = genie::utils::xml::TrimSpaces(
+  string content = genie::utils::xml::TrimSpacesClean(
       xmlNodeListGetString(xml_doc, node->xmlChildrenNode, 1) );
 
   vector<string> str_tokens = genie::utils::str::Split(content, ",");
@@ -233,7 +241,7 @@ double genie::utils::xml::GetDouble(xmlDocPtr xml_doc, string node_path)
   if(node==NULL) {
     return -999999;
   }
-  string content = genie::utils::xml::TrimSpaces(
+  string content = genie::utils::xml::TrimSpacesClean(
       xmlNodeListGetString(xml_doc, node->xmlChildrenNode, 1) );
   double value = atof(content.c_str());
   return value;
@@ -249,7 +257,7 @@ vector<double>
     return array;
   }
 
-  string content = genie::utils::xml::TrimSpaces(
+  string content = genie::utils::xml::TrimSpacesClean(
       xmlNodeListGetString(xml_doc, node->xmlChildrenNode, 1) );
 
   vector<string> str_tokens = genie::utils::str::Split(content, ",");
@@ -268,7 +276,7 @@ string genie::utils::xml::GetString(xmlDocPtr xml_doc, string node_path)
   if(node==NULL) {
     return "";
   }
-  string content = genie::utils::xml::TrimSpaces(
+  string content = genie::utils::xml::TrimSpacesClean(
       xmlNodeListGetString(xml_doc, node->xmlChildrenNode, 1) );
   return content;
 }

--- a/src/Framework/Utils/XmlParserUtils.cxx
+++ b/src/Framework/Utils/XmlParserUtils.cxx
@@ -120,7 +120,9 @@ string genie::utils::xml::GetXMLFilePath(string basename)  {
   size_t np = paths.size();
   for ( size_t i=0; i< np; ++i ) {
     const char* tmppath = paths[i].c_str();
-    std::string onepath = gSystem->ExpandPathName(tmppath);
+    auto expanded_path = gSystem->ExpandPathName(tmppath);
+    std::string onepath (expanded_path);
+    delete[] expanded_path;
     onepath += "/";
     onepath += basename;
     bool noAccess = gSystem->AccessPathName(onepath.c_str());

--- a/src/Framework/Utils/XmlParserUtils.h
+++ b/src/Framework/Utils/XmlParserUtils.h
@@ -52,6 +52,7 @@ namespace xml   {
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 
   string TrimSpaces(xmlChar * xmls) ;
+  string TrimSpacesClean(xmlChar * xmls) ;
   // trim the leading/trailing spaces from an parsed xml string like in:
   //
   // "      I am a string with lots of spaces      " ---->

--- a/src/Physics/Decay/BaryonResonanceDecayer.cxx
+++ b/src/Physics/Decay/BaryonResonanceDecayer.cxx
@@ -610,7 +610,7 @@ bool BaryonResonanceDecayer::AcceptPionDecay( TLorentzVector pion,
   TLorentzVector delta_p4 = *(decay_particle->P4() );
 
   // find incoming lepton
-  TLorentzVector in_lep_p4( * (event -> Probe()-> GetP4()) ) ;
+  TLorentzVector in_lep_p4( * (event -> Probe()-> P4()) ) ;
 
   // find outgoing lepton
   Interaction * interaction = event->Summary();

--- a/src/Physics/Hadronization/Pythia6Hadro2019.cxx
+++ b/src/Physics/Hadronization/Pythia6Hadro2019.cxx
@@ -106,8 +106,6 @@ bool Pythia6Hadro2019::Hadronize(GHepRecord *
 
   int np = pythia_particles->GetEntries();
   assert(np>0);
-  TClonesArray * particle_list = new TClonesArray("genie::GHepParticle", np);
-  particle_list->SetOwner(true);
 
   // Hadronic 4vec
   TLorentzVector p4Had = kinematics.HadSystP4();

--- a/src/Physics/Multinucleon/EventGen/MECGenerator.cxx
+++ b/src/Physics/Multinucleon/EventGen/MECGenerator.cxx
@@ -338,7 +338,8 @@ void MECGenerator::AddFinalStateLepton(GHepRecord * event) const
 
   // Boosting the incoming neutrino to the NN-cluster rest frame
   // Neutrino 4p
-  TLorentzVector * p4v = event->Probe()->GetP4(); // v 4p @ LAB
+  // TLorentzVector * p4v = event->Probe()->GetP4(); // v 4p @ LAB
+  auto p4v = std::unique_ptr<TLorentzVector>(event->Probe()->GetP4());
   p4v->Boost(-1.*beta);                           // v 4p @ NN-cluster rest frame
 
   // Look-up selected kinematics

--- a/src/Physics/Multinucleon/EventGen/MECGenerator.cxx
+++ b/src/Physics/Multinucleon/EventGen/MECGenerator.cxx
@@ -12,6 +12,7 @@
 //____________________________________________________________________________
 
 #include <TMath.h>
+#include <memory>
 #include "Math/Minimizer.h"
 #include "Math/Factory.h"
 
@@ -1355,7 +1356,8 @@ double MECGenerator::GetXSecMaxTlctl( const Interaction & in,
 				      const Range1D_t & Tl_range,
 				      const Range1D_t & ctl_range ) const {
 
-  ROOT::Math::Minimizer * min = ROOT::Math::Factory::CreateMinimizer("Minuit2");
+  auto min = std::unique_ptr<ROOT::Math::Minimizer>{
+      ROOT::Math::Factory::CreateMinimizer("Minuit2")};
 
   double Enu = in.InitState().ProbeE(kRfHitNucRest);
   double LepMass = in.FSPrimLepton()->Mass();

--- a/src/Physics/Multinucleon/XSection/EmpiricalMECPXSec2015.cxx
+++ b/src/Physics/Multinucleon/XSection/EmpiricalMECPXSec2015.cxx
@@ -45,7 +45,7 @@ XSecAlgorithmI("genie::EmpiricalMECPXSec2015", config)
 //____________________________________________________________________________
 EmpiricalMECPXSec2015::~EmpiricalMECPXSec2015()
 {
-
+  delete fXSecIntegrator;
 }
 //____________________________________________________________________________
 double EmpiricalMECPXSec2015::XSec(

--- a/src/Physics/NuclearState/FermiMomentumTablePool.cxx
+++ b/src/Physics/NuclearState/FermiMomentumTablePool.cxx
@@ -176,7 +176,7 @@ XmlParserStatus_t FermiMomentumTablePool::ParseXMLTables(string filename)
              bool isp = !xmlStrcmp(xml_cur->name, ptag);
              bool isn = !xmlStrcmp(xml_cur->name, ntag);
              if(isn || isp) {
-               string skf = utils::xml::TrimSpaces(
+               string skf = utils::xml::TrimSpacesClean(
                   xmlNodeListGetString(xml_doc, xml_cur->xmlChildrenNode, 1));
                kf = atof(skf.c_str());
              }

--- a/src/Tools/Flux/GNuMIFlux.cxx
+++ b/src/Tools/Flux/GNuMIFlux.cxx
@@ -2576,7 +2576,7 @@ void GNuMIFluxXMLHelper::ParseParamSet(xmlDocPtr& xml_doc, xmlNodePtr& xml_pset)
       utils::xml::TrimSpaces(const_cast<xmlChar*>(xml_child->name));
     if ( pname == "text" || pname == "comment" ) continue;
     string pval  =
-      utils::xml::TrimSpaces(
+      utils::xml::TrimSpacesClean(
               xmlNodeListGetString(xml_doc, xml_child->xmlChildrenNode, 1));
 
     if ( fVerbose > 1 )
@@ -2656,7 +2656,7 @@ void GNuMIFluxXMLHelper::ParseBeamDir(xmlDocPtr& xml_doc, xmlNodePtr& xml_beamdi
       utils::xml::GetAttribute(xml_beamdir,"type"));
 
   string pval  =
-    utils::xml::TrimSpaces(
+    utils::xml::TrimSpacesClean(
       xmlNodeListGetString(xml_doc, xml_beamdir->xmlChildrenNode, 1));
 
   if        ( dirtype == "series" ) {
@@ -2788,7 +2788,7 @@ void GNuMIFluxXMLHelper::ParseRotSeries(xmlDocPtr& xml_doc, xmlNodePtr& xml_pset
     if ( name == "text" || name == "comment" ) continue;
 
     if ( name == "rotation" ) {
-      string val = utils::xml::TrimSpaces(
+      string val = utils::xml::TrimSpacesClean(
           xmlNodeListGetString(xml_doc, xml_child->xmlChildrenNode, 1));
       string axis =
         utils::str::TrimSpaces(utils::xml::GetAttribute(xml_child,"axis"));
@@ -2836,7 +2836,7 @@ void GNuMIFluxXMLHelper::ParseWindowSeries(xmlDocPtr& xml_doc, xmlNodePtr& xml_p
 
     if ( name == "point" ) {
       string val  =
-        utils::xml::TrimSpaces(
+        utils::xml::TrimSpacesClean(
           xmlNodeListGetString(xml_doc, xml_child->xmlChildrenNode, 1));
       string coord =
         utils::str::TrimSpaces(utils::xml::GetAttribute(xml_child,"coord"));


### PR DESCRIPTION
This is a side-product when invegesting some memory leak with GENIE in JUNO (which turns out to be issues in certain ROOT version). But profiling of memory allocation and deallocation (`fsanitize=leak`) inside GENIE showed some memroy leak. I cleaned some of them (that happens multiple times).

Most issues are kind of equivalent to 
```cpp
int p = *(new int); // but the new is hidden in function call that not that obvious. 
```
Also, I add a function `TrimSpacesClean` next to `TrimSpaces` to clean memory allocated by `xmlNodeListGetString`.  
