### PR TITLE
properly protect against use of pythia8 object when only building pythia6

### DIFF
--- a/src/Framework/Utils/Pythia8Singleton.cxx
+++ b/src/Framework/Utils/Pythia8Singleton.cxx
@@ -26,15 +26,19 @@ Pythia8Singleton * Pythia8Singleton::fInstance = 0;
 Pythia8Singleton::Pythia8Singleton()
 {
   fInstance = 0;
+#ifdef __GENIE_PYTHIA8_ENABLED__
   fPythia   = 0;
+#endif
 
 }
 //____________________________________________________________________________
 Pythia8Singleton::~Pythia8Singleton()
 {
+#ifdef __GENIE_PYTHIA8_ENABLED__
   if (fPythia) {
     delete fPythia;
   }
+#endif
   fInstance = 0;
 }
 //____________________________________________________________________________
@@ -46,8 +50,10 @@ Pythia8Singleton * Pythia8Singleton::Instance()
 
     fInstance = new Pythia8Singleton;
 
+#ifdef __GENIE_PYTHIA8_ENABLED__
     // actually create the one to be held
     fInstance->fPythia = new Pythia8::Pythia();
+#endif
   }
   return fInstance;
 }


### PR DESCRIPTION
add some cases of "#ifdef __GENIE_PYTHIA8_ENABLED__ ... #endif"