### PR TITLE
Make the use of Professor2 fully optional 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ else
 endif
 
 lib-professor2-build: FORCE
-ifeq ($(strip $(GOPT_WITH_PROFESSOR2)),YES)
+ifeq ($(strip $(GOPT_ENABLE_PROFESSOR2)),YES)
 	@echo " "
 	@echo "** Building Professor2..."
 	cd ${GENIE}/src/ExternalLibs/professor && \
@@ -254,7 +254,7 @@ else
 endif
 
 lib-professor2-install: FORCE
-ifeq ($(strip $(GOPT_WITH_PROFESSOR2)),YES)
+ifeq ($(strip $(GOPT_ENABLE_PROFESSOR2)),YES)
 	@echo " "
 	@echo "** Building Professor2..."
 	cp ${GENIE}/src/ExternalLibs/professor/lib/libProfessor2.so ${GENIE_LIB_INSTALLATION_PATH}

--- a/configure
+++ b/configure
@@ -1002,6 +1002,7 @@ print MKCONF "GOPT_ENABLE_PROFILER=$gopt_enable_profiler\n";
 print MKCONF "GOPT_ENABLE_DOXYGEN_DOC=$gopt_enable_doxygen_doc\n";
 print MKCONF "GOPT_ENABLE_GFORTRAN=$gopt_enable_gfortran\n";
 print MKCONF "GOPT_ENABLE_G2C=$gopt_enable_g2c\n";
+print MKCONF "GOPT_ENABLE_PROFESSOR2=$gopt_enable_professor2\n";
 print MKCONF "GOPT_WITH_COMPILER=$gopt_with_compiler\n";
 print MKCONF "GOPT_WITH_CXX_DEBUG_FLAG=$gopt_with_cxx_debug_flag\n";
 print MKCONF "GOPT_WITH_CXX_OPTIMIZ_FLAG=-$gopt_with_cxx_optimiz_flag\n";
@@ -1028,7 +1029,6 @@ print MKCONF "GOPT_WITH_GEANT4_INC=$gopt_with_geant4_inc\n";
 print MKCONF "GOPT_WITH_GEANT4_LIB=$gopt_with_geant4_lib\n";
 print MKCONF "GOPT_WITH_GFORTRAN_LIB=$gopt_with_gfortran_lib\n";
 print MKCONF "GOPT_WITH_G2C_LIB=$gopt_with_g2c_lib\n";
-print MKCONF "GOPT_WITH_PROFESSOR2=$gopt_enable_professor2\n";
 close(MKCONF);
 
 print "\nYour input configuration options were: @ARGV";

--- a/src/make/Make.include
+++ b/src/make/Make.include
@@ -269,8 +269,13 @@ endif
 # Professor2
 #-------------------------------------------------------------------
 
+PROFESSOR2_INCLUDES =
+PROFESSOR2_LIBRARIES =
+
+ifeq ($(strip $(GOPT_ENABLE_PROFESSOR2)),YES)
 PROFESSOR2_INCLUDES = -I$(GENIE)/src/ExternalLibs/professor/include
 PROFESSOR2_LIBRARIES = -L$(GENIE)/src/ExternalLibs/professor/lib -lProfessor2
+endif
 
 #-------------------------------------------------------------------
 # ROOT

--- a/src/scripts/setup/genie-write-gbuild
+++ b/src/scripts/setup/genie-write-gbuild
@@ -143,6 +143,13 @@ if(@nret>0)
       { print GBLD   "#define __GENIE_HEAVY_NEUTRAL_LEPTON_ENABLED__\n"; }
 else  { print GBLD "//#define __GENIE_HEAVY_NEUTRAL_LEPTON_ENABLED__\n"; }
 
+# professor2 enabled?
+#
+@nret = `grep 'GOPT_ENABLE_PROFESSOR2=YES' $GCONF_FILE`;
+if(@nret>0)
+      { print GBLD   "#define __GENIE_PROFESSOR2_ENABLED__\n"; }
+else  { print GBLD "//#define __GENIE_PROFESSOR2_ENABLED__\n"; }
+
 # grab libxml2 version information
 #
 $libxml2_inc = "";


### PR DESCRIPTION
Primarily change GOPT_WITH_PROFESSOR2 to GOPT_ENABLE_PROFESSOR2 for consistency sake and to keep Make.config_no_paths contain the option for use on the Reweight side.  Set the #define in GBuild.h  accordingly.  Also leave the PROFESSOR2_{INCLUDES|LIBRARIES} Makefile variables blank if it's not enabled.

