### PR TITLE
adding MEC-EM mode

### DIFF
--- a/config/AR23_20i/ModelConfiguration.xml
+++ b/config/AR23_20i/ModelConfiguration.xml
@@ -134,7 +134,8 @@ University of Liverpool
   
   <param type="alg" name="XSecModel@genie::EventGenerator/MEC-CC">         genie::SuSAv2MECPXSec/Default         </param>
   <param type="alg" name="XSecModel@genie::EventGenerator/MEC-NC">         genie::EmpiricalMECPXSec2015/Default  </param>
-  
+  <param type="alg" name="XSecModel@genie::EventGenerator/MEC-EM">         genie::SuSAv2MECPXSec/Default         </param>
+
   <param type="alg" name="XSecModel@genie::EventGenerator/NucleonDecay">   genie::DummyPXSec/Default             </param>
   <param type="alg" name="XSecModel@genie::EventGenerator/NNBarOsc">       genie::NNBarOscDummyPXSec/Default     </param>
 


### PR DESCRIPTION
The AR23_20i tune doesn't work for electrons due to the missing MEC-EM mode. I have added it back. The modes for QEL-EM, RES-EM and DIS-EM are present.

https://github.com/GENIE-MC/Generator/issues/443