### PR TITLE
Constrained lower limit for EDnu integration.

### DIFF
--- a/src/Physics/XSectionIntegration/GSLXSecFunc.cxx
+++ b/src/Physics/XSectionIntegration/GSLXSecFunc.cxx
@@ -191,6 +191,7 @@ Range1D_t genie::utils::gsl::dXSec_dEDNu_E::IntegrationRange() const
   const double D = sqrt(B*B - A*C);
   // Range1D_t DNuEnergy((B - D)/A, (B + D)/A);
   // 12_04_2025 applying an upper bound on Ttarget at 1 GeV^2/2M --> lower bound on the integration range
+  //            Otherwise the integral does funny things. 
   const double Tmax = std::min(E - ((B - D) / A), (1. / (2 * M)));
   Range1D_t DNuEnergy(E - Tmax, (B + D) / A);
   return DNuEnergy;

--- a/src/Physics/XSectionIntegration/GSLXSecFunc.cxx
+++ b/src/Physics/XSectionIntegration/GSLXSecFunc.cxx
@@ -189,10 +189,11 @@ Range1D_t genie::utils::gsl::dXSec_dEDNu_E::IntegrationRange() const
   const double B = (M+E) * (E*M + 0.5*fDNuMass2);
   const double C = E*E *(M2 + fDNuMass2) + E*M*fDNuMass2 + 0.25*fDNuMass2*fDNuMass2;
   const double D = sqrt(B*B - A*C);
-
-  Range1D_t DNuEnergy((B - D)/A, (B + D)/A);
+  // Range1D_t DNuEnergy((B - D)/A, (B + D)/A);
+  // 12_04_2025 applying an upper bound on Ttarget at 1 GeV^2/2M --> lower bound on the integration range
+  const double Tmax = std::min(E - ((B - D) / A), (1. / (2 * M)));
+  Range1D_t DNuEnergy(E - Tmax, (B + D) / A);
   return DNuEnergy;
-
 }
 //____________________________________________________________________________
 genie::utils::gsl::d2XSec_dxdy_E::d2XSec_dxdy_E(


### PR DESCRIPTION
Update to the DarkNeutrino module cross sections.
Applied a lower cut to the range of integration over E_DNu in order to correct the unphysical behaviour of the total cross-sections.
The cut corresponds to a Q^2(Max) < 1 GeV^2, above which the differential cross-sections are negligible.