### PR TITLE
use smart pointers to avoid potential memory leak in GRV98LO

### DIFF
--- a/src/Physics/PartonDistributions/GRV98LO.cxx
+++ b/src/Physics/PartonDistributions/GRV98LO.cxx
@@ -23,25 +23,13 @@ using namespace genie;
 
 //____________________________________________________________________________
 GRV98LO::GRV98LO() :
-PDFModelI("genie::GRV98LO"),
- fXUVF(NULL),
- fXDVF(NULL),
- fXDEF(NULL),
- fXUDF(NULL),
- fXSF (NULL),
- fXGF (NULL)
+PDFModelI("genie::GRV98LO")
 {
   this->Initialize();
 }
 //____________________________________________________________________________
 GRV98LO::GRV98LO(string config) :
-PDFModelI("genie::GRV98LO", config),
- fXUVF(NULL),
- fXDVF(NULL),
- fXDEF(NULL),
- fXUDF(NULL),
- fXSF (NULL),
- fXGF (NULL)
+PDFModelI("genie::GRV98LO", config)
 {
   LOG("GRV98LO", pDEBUG) << "GRV98LO configuration:\n " << GetConfig() ;
 
@@ -49,14 +37,7 @@ PDFModelI("genie::GRV98LO", config),
 }
 //____________________________________________________________________________
 GRV98LO::~GRV98LO()
-{
-  if (fXUVF) {delete fXUVF; fXUVF = NULL;}
-  if (fXDVF) {delete fXDVF; fXDVF = NULL;}
-  if (fXDEF) {delete fXDEF; fXDEF = NULL;}
-  if (fXUDF) {delete fXUDF; fXUDF = NULL;}
-  if (fXSF ) {delete fXSF ; fXSF  = NULL;}
-  if (fXGF ) {delete fXGF ; fXGF  = NULL;}
-}
+{}
 //____________________________________________________________________________
 double GRV98LO::UpValence(double x, double Q2) const
 {
@@ -330,12 +311,12 @@ void GRV98LO::Initialize(void)
     k++;
   }
 
-  fXUVF = new Interpolator2D(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXUVF[0]);
-  fXDVF = new Interpolator2D(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXDVF[0]);
-  fXDEF = new Interpolator2D(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXDEF[0]);
-  fXUDF = new Interpolator2D(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXUDF[0]);
-  fXSF  = new Interpolator2D(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXSF [0]);
-  fXGF  = new Interpolator2D(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXGF [0]);
+  fXUVF = std::make_unique<Interpolator2D>(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXUVF[0]);
+  fXDVF = std::make_unique<Interpolator2D>(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXDVF[0]);
+  fXDEF = std::make_unique<Interpolator2D>(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXDEF[0]);
+  fXUDF = std::make_unique<Interpolator2D>(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXUDF[0]);
+  fXSF  = std::make_unique<Interpolator2D>(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXSF [0]);
+  fXGF  = std::make_unique<Interpolator2D>(gridLogXbj.size(),&gridLogXbj[0],gridLogQ2.size(),&gridLogQ2[0],&knotsXGF [0]);
 
   fInitialized = true;
 }

--- a/src/Physics/PartonDistributions/GRV98LO.h
+++ b/src/Physics/PartonDistributions/GRV98LO.h
@@ -32,6 +32,8 @@
 #include "Physics/PartonDistributions/PDFModelI.h"
 #include "Framework/Numerical/Interpolator2D.h"
 
+#include <memory>
+
 namespace genie {
 
 class GRV98LO: public PDFModelI {
@@ -84,12 +86,12 @@ private:
   //
   // arrays for the interpolation routine
   //
-  Interpolator2D * fXUVF; // = f(logx,logQ2)
-  Interpolator2D * fXDVF;
-  Interpolator2D * fXDEF;
-  Interpolator2D * fXUDF;
-  Interpolator2D * fXSF;
-  Interpolator2D * fXGF;
+  std::unique_ptr<Interpolator2D> fXUVF; // = f(logx,logQ2)
+  std::unique_ptr<Interpolator2D> fXDVF;
+  std::unique_ptr<Interpolator2D> fXDEF;
+  std::unique_ptr<Interpolator2D> fXUDF;
+  std::unique_ptr<Interpolator2D> fXSF;
+  std::unique_ptr<Interpolator2D> fXGF;
 };
 
 }         // genie namespace


### PR DESCRIPTION
If `Configure()` is called multiple times on the same GRV98LO instance, the `new`s in `Intitialize()` will leak memory.   (The pointers are only deleted in the destructor as it stands.) This can be cleanly avoided by using smart pointers instead of direct allocation.  (It's also possible to explicitly `delete` them, of course, but in 2025 smart pointers are almost certainly the recommended solution?)

I stumbled across this by accidentally repeatedly calling `Reconfigure()` on a `genie::rew::GReWeight` instance that had a `genie::rew::GReWeightNuXSecDIS` stored inside it, inside a tight loop, and quickly wedging the machine I was working on when it ran out of memory and tried to start swapping.