### PR TITLE
correctly record the phase space used in RES calculator

### DIFF
--- a/src/Physics/Resonance/EventGen/RESKinematicsGenerator.cxx
+++ b/src/Physics/Resonance/EventGen/RESKinematicsGenerator.cxx
@@ -196,8 +196,12 @@ void RESKinematicsGenerator::ProcessEventRecord(GHepRecord * evrec) const
         double M = init_state.Tgt().HitNucP4().M();
         kinematics::WQ2toXY(E,M,gW,gQ2,gx,gy);
 
-        // set the cross section for the selected kinematics
-        evrec->SetDiffXSec(xsec,acceptKps);
+        // set the cross section for the selected kinematics.
+        // note that we're saving to the evt record in the more familiar "W*Q2" space
+        // rather than the "W*Q2D" (precomputed dipole) space that's used above
+        // for generation efficiency in the accept-reject loop
+        double J = kinematics::Jacobian(interaction, kPSWQD2fE, kPSWQ2fE);
+        evrec->SetDiffXSec(J * xsec, kPSWQ2fE);
 
         // for uniform kinematics, compute an event weight as
         // wght = (phase space volume)*(differential xsec)/(event total xsec)

--- a/src/Physics/Resonance/EventGen/RESKinematicsGenerator.cxx
+++ b/src/Physics/Resonance/EventGen/RESKinematicsGenerator.cxx
@@ -166,7 +166,8 @@ void RESKinematicsGenerator::ProcessEventRecord(GHepRecord * evrec) const
      interaction->KinePtr()->SetQ2(gQ2);
 
      //-- Computing cross section for the current kinematics
-     xsec = fXSecModel->XSec(interaction, kPSWQD2fE);
+     const EKinePhaseSpace acceptKps = kPSWQD2fE;
+     xsec = fXSecModel->XSec(interaction, acceptKps);
 
      //-- Decide whether to accept the current kinematics
      if(!fGenerateUniformly) 
@@ -196,12 +197,12 @@ void RESKinematicsGenerator::ProcessEventRecord(GHepRecord * evrec) const
         kinematics::WQ2toXY(E,M,gW,gQ2,gx,gy);
 
         // set the cross section for the selected kinematics
-        evrec->SetDiffXSec(xsec,kPSWQ2fE);
+        evrec->SetDiffXSec(xsec,acceptKps);
 
         // for uniform kinematics, compute an event weight as
         // wght = (phase space volume)*(differential xsec)/(event total xsec)
         if(fGenerateUniformly) {
-          double vol     = kinematics::PhaseSpaceVolume(interaction,kPSWQ2fE);
+          double vol     = kinematics::PhaseSpaceVolume(interaction,acceptKps);
           double totxsec = evrec->XSec();
           double wght    = (vol/totxsec)*xsec;
           LOG("RESKinematics", pNOTICE)  << "Kinematics wght = "<< wght;

--- a/src/Physics/Resonance/EventGen/RESKinematicsGenerator.cxx
+++ b/src/Physics/Resonance/EventGen/RESKinematicsGenerator.cxx
@@ -166,9 +166,7 @@ void RESKinematicsGenerator::ProcessEventRecord(GHepRecord * evrec) const
      interaction->KinePtr()->SetQ2(gQ2);
 
      //-- Computing cross section for the current kinematics
-     const EKinePhaseSpace acceptKps = kPSWQD2fE;
-     xsec = fXSecModel->XSec(interaction, acceptKps);
-
+     xsec = fXSecModel->XSec(interaction, kPSWQD2fE);
      //-- Decide whether to accept the current kinematics
      if(!fGenerateUniformly) 
      {
@@ -197,16 +195,17 @@ void RESKinematicsGenerator::ProcessEventRecord(GHepRecord * evrec) const
         kinematics::WQ2toXY(E,M,gW,gQ2,gx,gy);
 
         // set the cross section for the selected kinematics.
-        // note that we're saving to the evt record in the more familiar "W*Q2" space
+        // we're converting here to the more familiar "W*Q2" space
         // rather than the "W*Q2D" (precomputed dipole) space that's used above
         // for generation efficiency in the accept-reject loop
         double J = kinematics::Jacobian(interaction, kPSWQD2fE, kPSWQ2fE);
-        evrec->SetDiffXSec(J * xsec, kPSWQ2fE);
+        xsec *= J;
+        evrec->SetDiffXSec(xsec, kPSWQ2fE);
 
         // for uniform kinematics, compute an event weight as
         // wght = (phase space volume)*(differential xsec)/(event total xsec)
         if(fGenerateUniformly) {
-          double vol     = kinematics::PhaseSpaceVolume(interaction,acceptKps);
+          double vol     = kinematics::PhaseSpaceVolume(interaction,kPSWQ2fE);
           double totxsec = evrec->XSec();
           double wght    = (vol/totxsec)*xsec;
           LOG("RESKinematics", pNOTICE)  << "Kinematics wght = "<< wght;


### PR DESCRIPTION
After some adjustments to the variables acceptance/rejection sampling for the RES calculator was using a couple years ago, when RES events were stored, the phase space variables used were not correctly stored in the event---instead the wrong set of variables were.  This PR fixes that oversight.