### PR TITLE
fix distclean of Apps; had wrong source name and wildcarding pattern

### DIFF
--- a/src/Apps/Makefile
+++ b/src/Apps/Makefile
@@ -297,7 +297,7 @@ clean: FORCE
 	$(RM) $(TGT)
 
 distclean: FORCE
-	$(RM) $(patsubst $(GENIE_BIN_DIR),$(GENIE_BIN_INSTALLATION_PATH),$(TGT))
+	$(RM) $(patsubst $(GENIE_BIN_PATH)%,$(GENIE_BIN_INSTALLATION_PATH)%,$(TGT))
 
 FORCE:
 


### PR DESCRIPTION
distclean for the Apps was always wonky
turns out it was cleaning out $(GENIE_BIN_PATH) instead of $(GENIE_BIN_INSTALLATION_PATH) due to incorrect use of make's patsubst and the use of $(GENIE_BIN_DIR) where it should have been $(GENIE_BIN_PATH)