### PR TITLE
Fix missing IsAboveThreshold check for single pion production.

### DIFF
--- a/src/Framework/Interaction/KPhaseSpace.cxx
+++ b/src/Framework/Interaction/KPhaseSpace.cxx
@@ -3,7 +3,7 @@
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
 
- Costas Andreopoulos <constantinos.andreopoulos \at cern.ch>
+ Costas Andreopoulos <c.andreopoulos \at cern.ch>
  University of Liverpool
 
  Changes required to implement the GENIE Boosted Dark Matter module


### PR DESCRIPTION
Recently, a separate scattering type was introduced for single pion production.
However, the corresponding check in IsAboveThreshold was missing.
This omission could cause the event generation to enter an infinite loop (e.g. with the MK19_00a_00_000 tune).

This PR adds the missing threshold check for the single pion scattering type.