### PR TITLE
Improve APFEL detection: support modern CMake builds (no .la)

### DIFF
--- a/configure
+++ b/configure
@@ -589,12 +589,17 @@ if($gopt_enable_apfel eq "YES") {
     }
     print "Setting --with-apfel-lib=$gopt_with_apfel_lib\n";
   }
-  # check
-  my $file    = "$gopt_with_apfel_lib/libAPFEL.la";
-  if(! -e $file) {
-     print "*** Error *** You need to specify the path to APFEL library using --with-apfel-lib=/some/path/\n";
-     print "*** Error *** Otherwise, you should --disable-apfel\n\n";
-     exit 1;
+
+  # check for APFEL libraries
+  my $file_so = "$gopt_with_apfel_lib/libAPFEL.so";
+  my $file_a  = "$gopt_with_apfel_lib/libAPFEL.a";
+  my $file_la = "$gopt_with_apfel_lib/libAPFEL.la";
+  
+  if(! -e $file_so && ! -e $file_a && ! -e $file_la) {
+      print "*** Error *** Could not find libAPFEL.[so|a|la] in $gopt_with_apfel_lib\n";
+      print "*** Error *** You need to specify the path to APFEL library using --with-apfel-lib=/some/path/\n";
+      print "*** Error *** Otherwise, you should --disable-apfel\n\n";
+      exit 1;
   }
 }
 

--- a/configure
+++ b/configure
@@ -583,11 +583,22 @@ if($gopt_enable_apfel eq "YES") {
   # if it still not set, try autodetecting it
   if(! -d $gopt_with_apfel_lib && $auto_detect)  {
     print "Auto-detecting APFEL library path...\n";
-    $matched = auto_detect("libAPFEL.la");
-    if( $matched=~m/(\S*)\/libAPFEL.la/i ) {
-       $gopt_with_apfel_lib = $1;
+
+    my $matchfile = "";
+    my @apfel_candidates = ("libAPFEL.so", "libAPFEL.a", "libAPFEL.la");
+
+    foreach my $cand (@apfel_candidates) {
+      $matched = auto_detect($cand);
+      if(defined $matched && $matched ne "") {
+        $matchfile = $matched;
+        last;
+      }
     }
-    print "Setting --with-apfel-lib=$gopt_with_apfel_lib\n";
+
+    if($matchfile =~ m{(\S*)/libAPFEL\.(?:so|a|la)}i) {
+      $gopt_with_apfel_lib = $1;
+      print "Setting --with-apfel-lib=$gopt_with_apfel_lib\n";
+    }
   }
 
   # check for APFEL libraries


### PR DESCRIPTION
Configure: accept APFEL libraries without .la (support .so and .a)

Replaced legacy check for libAPFEL.la with a broader test that accepts
libAPFEL.so, libAPFEL.a, or libAPFEL.la. This allows using modern APFEL
installations built with CMake (which no longer generate .la files).
