### PR TITLE
Adds a `SplinePostProcessor` singleton class to Generator

### DIFF
--- a/config/Messenger.xml
+++ b/config/Messenger.xml
@@ -205,6 +205,7 @@
   <priority msgstream="SpectralFunc1">         NOTICE </priority>
   <priority msgstream="SpectralFunc">          NOTICE </priority>
   <priority msgstream="Spline">                INFO   </priority>
+  <priority msgstream="SplinePostProcessor">   WARN   </priority>
   <priority msgstream="Target">                INFO   </priority>
   <priority msgstream="Utils">                 INFO   </priority>
   <priority msgstream="Vtx">                   WARN   </priority>

--- a/config/SplinePostProcessor.xml
+++ b/config/SplinePostProcessor.xml
@@ -25,8 +25,8 @@ Widths                    vec-double  no    Reference widths of the Gaussian ker
     <param type="vec-double" delim="," name="Stops"> 0.1,0.2,0.5,1.0,2.0,5.0,10.0,50.0,100.0 </param>
     <param type="vec-double" delim="," name="Widths"> 0.005,0.01,0.025,0.05,0.1,0.25,0.47,2.34,4.7 </param>
     <!-- separate list for nutau due to high thresholds -->
-    <param type="vec-double" delim="," name="Stops@Pdg=16,-16"> 2.8,3.0,3.5,4.0,5.0,7.5,10.0,50.0,100.0 </param>
-    <param type="vec-double" delim="," name="Widths@Pdg=16,-16"> 0.005,0.01,0.025,0.05,0.1,0.25,0.47,2.34,4.7 </param>
+    <param type="vec-double" delim="," name="Stops@Pdg=16,-16"> 2.8,3.0,4.0,5.0,10.0 </param>
+    <param type="vec-double" delim="," name="Widths@Pdg=16,-16"> 0.005,0.01,0.03,0.075,0.1 </param>
 
     <param type="bool" name="UsePostProcessing"> true </param>
 

--- a/config/SplinePostProcessor.xml
+++ b/config/SplinePostProcessor.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!--
+Configuration for the SplinePostProcessor
+Tool that forces Gaussian kernel smoothing on selected algorithms
+
+Algorithm Configurable Parameters:
+..............................................................................................................................
+Name                      Type        Opt   Comment                                           Default
+..............................................................................................................................
+
+************                                *******************************
+set Default:                                Generic configuration parameter
+************                                *******************************
+HandledAlgorithms         vec-string  no    Keys of algorithms handled by this tool.
+Stops                     vec-double  no    Reference neutrino energies at which the Gaussian kernel has given width
+Widths                    vec-double  no    Reference widths of the Gaussian kernel at specific neutrino energies
+-->
+
+<alg_conf>
+
+  <param_set name="Default">
+
+    <param type="vec-string" delim="," name="HandledAlgorithms"> genie::NievesQELCCPXSec/ZExp </param>
+    <param type="vec-double" delim="," name="Stops"> 0.1,0.2,0.5,1.0,2.0,5.0,10.0,50.0,100.0 </param>
+    <param type="vec-double" delim="," name="Widths"> 0.005,0.01,0.025,0.05,0.1,0.25,0.47,2.34,4.7 </param>
+
+  </param_set>
+
+</alg_conf>

--- a/config/SplinePostProcessor.xml
+++ b/config/SplinePostProcessor.xml
@@ -24,6 +24,10 @@ Widths                    vec-double  no    Reference widths of the Gaussian ker
     <param type="vec-string" delim="," name="HandledAlgorithms"> genie::NievesQELCCPXSec/ZExp </param>
     <param type="vec-double" delim="," name="Stops"> 0.1,0.2,0.5,1.0,2.0,5.0,10.0,50.0,100.0 </param>
     <param type="vec-double" delim="," name="Widths"> 0.005,0.01,0.025,0.05,0.1,0.25,0.47,2.34,4.7 </param>
+    <!-- separate list for nutau due to high thresholds -->
+    <param type="vec-double" delim="," name="Stops@Pdg=16,-16"> 2.8,3.0,3.5,4.0,5.0,7.5,10.0,50.0,100.0 </param>
+    <param type="vec-double" delim="," name="Widths@Pdg=16,-16"> 0.005,0.01,0.025,0.05,0.1,0.25,0.47,2.34,4.7 </param>
+
     <param type="bool" name="UsePostProcessing"> true </param>
 
   </param_set>

--- a/config/SplinePostProcessor.xml
+++ b/config/SplinePostProcessor.xml
@@ -24,6 +24,7 @@ Widths                    vec-double  no    Reference widths of the Gaussian ker
     <param type="vec-string" delim="," name="HandledAlgorithms"> genie::NievesQELCCPXSec/ZExp </param>
     <param type="vec-double" delim="," name="Stops"> 0.1,0.2,0.5,1.0,2.0,5.0,10.0,50.0,100.0 </param>
     <param type="vec-double" delim="," name="Widths"> 0.005,0.01,0.025,0.05,0.1,0.25,0.47,2.34,4.7 </param>
+    <param type="bool" name="UsePostProcessing"> true </param>
 
   </param_set>
 

--- a/config/master_config.xml
+++ b/config/master_config.xml
@@ -179,6 +179,9 @@
    <config alg="genie::HEDISXSec">                   HEDISXSec.xml                   </config>
    <config alg="genie::BostedChristyEMPXSec">        BostedChristyEMPXSec.xml        </config>
 
+   <!--  ****** CONFIGURATION FOR GENERIC SPLINE POST PROCESSOR ****** -->
+   <config alg="genie::SplinePostProcessor">         SplinePostProcessor.xml         </config>
+
    <!--  ****** CONFIGURATION FOR XSEC ALGORITHMS ****** -->
    <config alg="genie::AhrensNCELPXSec">                    AhrensNCELPXSec.xml                    </config>
    <config alg="genie::AhrensDMELPXSec">                    AhrensDMELPXSec.xml                    </config>

--- a/src/Apps/gMakeSplines.cxx
+++ b/src/Apps/gMakeSplines.cxx
@@ -196,7 +196,6 @@ int main(int argc, char ** argv)
       GEVGDriver driver;
       driver.SetEventGeneratorList(RunOpt::Instance()->EventGeneratorList());
       driver.Configure(init_state);
-      LOG("gmkspl", pDEBUG) << "Configured for init_state:" << init_state;
       driver.CreateSplines(gOptNKnots, gOptMaxE);
     }
   }
@@ -374,8 +373,7 @@ PDGCodeList * GetNeutrinoCodes(void)
   vector<string>::const_iterator iter;
   for(iter = nuvec.begin(); iter != nuvec.end(); ++iter) {
     list->push_back( atoi(iter->c_str()) );
-  }
-  
+  }  
   return list;
 }
 //____________________________________________________________________________

--- a/src/Apps/gMakeSplines.cxx
+++ b/src/Apps/gMakeSplines.cxx
@@ -196,6 +196,7 @@ int main(int argc, char ** argv)
       GEVGDriver driver;
       driver.SetEventGeneratorList(RunOpt::Instance()->EventGeneratorList());
       driver.Configure(init_state);
+      LOG("gmkspl", pDEBUG) << "Configured for init_state:" << init_state;
       driver.CreateSplines(gOptNKnots, gOptMaxE);
     }
   }
@@ -374,6 +375,7 @@ PDGCodeList * GetNeutrinoCodes(void)
   for(iter = nuvec.begin(); iter != nuvec.end(); ++iter) {
     list->push_back( atoi(iter->c_str()) );
   }
+  
   return list;
 }
 //____________________________________________________________________________

--- a/src/Framework/Numerical/LinkDef.h
+++ b/src/Framework/Numerical/LinkDef.h
@@ -5,11 +5,15 @@
 #pragma link off all functions;
 
 #pragma link C++ namespace genie;
+#pragma link C++ namespace genie::exceptions;
 #pragma link C++ namespace genie::utils::math;
 #pragma link C++ namespace genie::utils::gsl;
 
 #pragma link C++ class genie::RandomGen;
 #pragma link C++ class genie::Spline;
+#pragma link C++ class genie::SplinePostProcessorI;
+#pragma link C++ class genie::exceptions::SplineProcessingException;
+#pragma link C++ class genie::SplinePostProcessor;
 #pragma link C++ class genie::BLI2DGrid;
 #pragma link C++ class genie::BLI2DUnifGrid;
 #pragma link C++ class genie::BLI2DNonUnifGrid;

--- a/src/Framework/Numerical/SplinePostProcessor.cxx
+++ b/src/Framework/Numerical/SplinePostProcessor.cxx
@@ -1,0 +1,245 @@
+//____________________________________________________________________________
+/*
+ Copyright (c) 2003-2025, The GENIE Collaboration
+ For the full text of the license visit http://copyright.genie-mc.org 
+
+ John Plows <kplows \at liverpool.ac.uk>
+ University of Liverpool 
+*/
+//____________________________________________________________________________
+
+#include "Framework/Numerical/SplinePostProcessor.h"
+#include "Framework/Messenger/Messenger.h"
+
+using std::string;
+using std::ostream;
+using std::vector;
+
+using namespace genie;
+
+//___________________________________________________________________________
+namespace genie::exceptions {
+  ostream & operator << (ostream & stream, 
+			 const SplineProcessingException & exception ) {
+    exception.Print(stream);
+    return stream;
+  }
+//___________________________________________________________________________
+  SplineProcessingException::SplineProcessingException() {
+    this->Init();
+  }
+//___________________________________________________________________________
+  SplineProcessingException::SplineProcessingException( const SplineProcessingException & exception ) {
+    this->Copy(exception);
+  }
+//___________________________________________________________________________
+  SplineProcessingException::SplineProcessingException( string reason, bool interrupt ) {
+    this->Init();
+    this->SetReason(reason);
+    this->SetInterrupt(interrupt);
+  }
+//___________________________________________________________________________
+  SplineProcessingException::~SplineProcessingException() {
+  
+  }
+//___________________________________________________________________________
+  void SplineProcessingException::Init(void) {
+    fReason = "";
+    fInterrupt = false;
+  }
+//___________________________________________________________________________
+  void SplineProcessingException::Copy(const SplineProcessingException & exception) {
+    fReason    = exception.fReason;
+    fInterrupt = exception.fInterrupt;
+  }
+//___________________________________________________________________________
+  void SplineProcessingException::Print(ostream & stream) const {
+    stream << "** EXCEPTION in SplinePostProcessor! Reason : " << this->ShowReason();
+    if( this->DoInterrupt() ) { 
+      stream << " *~*~*~* INTERRUPTING EXECUTION!! *~*~*~* \n";
+    }
+  }
+//___________________________________________________________________________
+} // namespace exceptions
+
+using namespace genie::exceptions;
+
+//___________________________________________________________________________
+SplinePostProcessor::SplinePostProcessor() : SplinePostProcessorI("genie::SplinePostProcessor") {
+  this->Init();
+}
+//___________________________________________________________________________
+SplinePostProcessor::SplinePostProcessor(string config) : 
+  SplinePostProcessorI("genie::SplinePostProcessor", config) {
+  this->Init();
+}
+//___________________________________________________________________________
+SplinePostProcessor::SplinePostProcessor(string name, string config) :
+  SplinePostProcessorI(name, config) {
+  this->Init();
+}
+//___________________________________________________________________________
+SplinePostProcessor::~SplinePostProcessor() {
+  fStops.clear();
+  fWidths.clear();
+  fAlgs.clear();
+}
+//___________________________________________________________________________
+void SplinePostProcessor::Init(void) {
+  LOG("SplinePostProcessor", pDEBUG) << "Initialising SplinePostProcessor...";
+  this->Configure("Default");
+}
+//___________________________________________________________________________
+void SplinePostProcessor::LoadConfig(void) {
+  fStops.clear(); fWidths.clear(); fAlgs.clear();
+  LOG("SplinePostProcessor", pDEBUG) << "Loading the SplinePostProcessor configuration...";
+
+  vector<string> alg_vect;
+  this->GetParamVect( "HandledAlgorithms", alg_vect );
+  // Drop these into the set for quick lookup
+  for( string alg : alg_vect ) { 
+    fAlgs.insert(alg);
+    LOG("SplinePostProcessor", pDEBUG) << "Will handle algorithm named " << alg;
+  }
+
+  this->GetParamVect( "Stops", fStops );
+  this->GetParamVect( "Widths", fWidths );
+  if( fStops.size() != fWidths.size() ) {
+    // The Algorithm has been misconfigured. It's early, so complain and ask user to fix.
+    LOG("SplinePostProcessor", pFATAL) << "Different number of stops and widths! "
+				       << " (" << fStops.size() << " vs " << fWidths.size() << ")";
+    throw SplineProcessingException("N stops != N widths", true);
+  }
+  
+}
+//___________________________________________________________________________
+void SplinePostProcessor::Configure(const Registry & config) {
+  Algorithm::Configure(config);
+  try {
+    this->LoadConfig();
+  } catch (SplineProcessingException exception) {
+    LOG("SplinePostProcessor", pFATAL) << exception;
+    exit(1);
+  }
+}
+//___________________________________________________________________________
+void SplinePostProcessor::Configure(std::string param_set) {
+  Algorithm::Configure(param_set);
+  try {
+    this->LoadConfig();
+  } catch (SplineProcessingException exception) {
+    LOG("SplinePostProcessor", pFATAL) << exception;
+    exit(1);
+  }
+}
+//___________________________________________________________________________
+bool SplinePostProcessor::IsHandled(std::string alg_name, std::string alg_config) {
+  std::string alg_key = alg_name + "/" + alg_config;
+  return (fAlgs.count(alg_key) != 0);
+}
+//___________________________________________________________________________
+bool SplinePostProcessor::IsHandled(const Algorithm * alg) {
+  std::string alg_key = alg->Id().Key();
+  return (fAlgs.count(alg_key) != 0);
+}
+//___________________________________________________________________________
+std::vector<double> SplinePostProcessor::ProcessSpline( const std::vector<double> E,
+							const std::vector<double> xsec ) const {
+
+  // Are the thresholds sensible?
+  std::vector<double> stops;
+  std::vector<double> widths;
+  try {
+    this->SetThresholds( stops, widths, E.front(), E.back() );
+  } catch (SplineProcessingException exception) {
+    if(exception.DoInterrupt()) {
+      LOG("SplinePostProcessor", pFATAL) << exception;
+      exit(1);
+    } else {
+      LOG("SplinePostProcessor", pERROR) << exception;
+    }
+  } // Set thresholds
+
+  // Read out the knots from the spline and put them into arrays
+  const int NKnots = E.size();
+  std::vector<double> new_xsec;
+
+  // Apply Gaussian kernel smoother here, with a linear activation function for widths
+  std::vector<double>::iterator it_stop  = stops.begin()+1;
+  std::vector<double>::iterator it_width = widths.begin()+1;
+
+  double w1 = widths.front(); double w2 = *it_width;
+  for( int i = 0; i < NKnots; i++ ) {
+    // Linear activation function between s1 and s2
+    auto activation = [&](const double s1, const double s2) {
+      if(E[i] <= s1) return 0.0;
+      if(E[i] >= s2) return 1.0;
+      return (E[i] - s1)/(s2 - s1);
+    };
+
+    if(E[i] > *it_stop && E[i] < stops.back()) { // Update iterators
+      it_stop++; it_width++;
+      w1 = w2; w2 = *(it_width);
+    }
+    
+    double rat = activation(*(it_stop-1), *(it_stop));
+    double width = w1 + (w2 - w1) * rat; // between w1 and w2
+    double num = 0.0; double den = 0.0;
+    for(int j = 0; j < NKnots; j++) {
+      double w = std::exp(-0.5 * std::pow((E[i] - E[j]) / width, 2.0)); // Gauss
+      num += w * xsec[j]; // weight * value
+      den += w; // total weight
+    }
+
+    // Knot value out
+    new_xsec.emplace_back( num / den );
+    
+  } // Loop over knots of spline; smooth each one by configurable width
+
+  return new_xsec;
+}
+//___________________________________________________________________________
+void SplinePostProcessor::SetThresholds( std::vector<double> & stops,
+					 std::vector<double> & widths,
+					 double xmin, double xmax ) const {
+  // Copy fStops and fWidths to the temp objects, and then start working on them
+  stops = fStops; widths = fWidths;
+  if( stops.front() > xmax || stops.back() < xmin ) { // Bad configuration, this will be nonsense.
+    throw SplineProcessingException("Thresholds out of bounds", true);
+    return;
+  }
+  
+  int n_rejected_front = 0; int n_rejected_back = 0;
+  while( stops.front() < xmin ) { // Throw out elements until we're in the range
+    stops.erase(stops.begin());
+    widths.erase(widths.begin());
+    n_rejected_front++;
+  }
+  while( stops.back() > xmax ) { // Throw out elements until we're in the range
+    stops.erase(stops.end()-1);
+    widths.erase(widths.end()-1);
+    n_rejected_back++;
+  }
+
+  if( stops.size() == 1 ) {  // Too few elements. Stop execution
+    throw SplineProcessingException("Not enough elements left to interpolate", true);
+  }
+
+  // If the xmin and/or xmax are outside first / last stop, add some with copies of width
+  if( xmin < stops.front() ) {
+    stops.insert(stops.begin(), xmin);
+    widths.insert(widths.begin(), widths.front());
+  }
+  if( xmax > stops.back() ) {
+    stops.emplace_back(xmax);
+    widths.emplace_back(widths.back());
+  }
+  
+  if(n_rejected_front > 0 || n_rejected_back > 0) { // Complain, but don't stop execution
+    LOG("SplinePostProcessor", pERROR) << "Removed " << n_rejected_front << " elements from the front"
+				       << " of the stops / widths vectors, and " << n_rejected_back
+				       << " from the back. Take note!";
+    throw SplineProcessingException("Using different stops to those configured");
+  }
+  return;
+}

--- a/src/Framework/Numerical/SplinePostProcessor.cxx
+++ b/src/Framework/Numerical/SplinePostProcessor.cxx
@@ -244,7 +244,7 @@ std::vector<double> SplinePostProcessor::ProcessSpline( const std::vector<double
       LOG("SplinePostProcessor", pFATAL) << exception;
       exit(1);
     } else {
-      LOG("SplinePostProcessor", pERROR) << exception;
+      LOG("SplinePostProcessor", pWARN) << exception;
     }
   } // Set thresholds
 
@@ -324,7 +324,7 @@ void SplinePostProcessor::SetThresholds( std::vector<double> & stops,
   }
   
   if(n_rejected_front > 0 || n_rejected_back > 0) { // Complain, but don't stop execution
-    LOG("SplinePostProcessor", pERROR) << "Removed " << n_rejected_front << " elements from the front"
+    LOG("SplinePostProcessor", pWARN)  << "Removed " << n_rejected_front << " elements from the front"
 				       << " of the stops / widths vectors, and " << n_rejected_back
 				       << " from the back. Take note!";
     throw SplineProcessingException("Using different stops to those configured");

--- a/src/Framework/Numerical/SplinePostProcessor.cxx
+++ b/src/Framework/Numerical/SplinePostProcessor.cxx
@@ -110,6 +110,8 @@ void SplinePostProcessor::LoadConfig(void) {
 				       << " (" << fStops.size() << " vs " << fWidths.size() << ")";
     throw SplineProcessingException("N stops != N widths", true);
   }
+
+  this->GetParam( "UsePostProcessing", fUsePostProcessing );
   
 }
 //___________________________________________________________________________
@@ -145,6 +147,11 @@ bool SplinePostProcessor::IsHandled(const Algorithm * alg) {
 //___________________________________________________________________________
 std::vector<double> SplinePostProcessor::ProcessSpline( const std::vector<double> E,
 							const std::vector<double> xsec ) const {
+
+  // If we don't want post processing, return out now.
+  if( !fUsePostProcessing ) {
+    return xsec;
+  } // no op if no post processing
 
   // Are the thresholds sensible?
   std::vector<double> stops;

--- a/src/Framework/Numerical/SplinePostProcessor.h
+++ b/src/Framework/Numerical/SplinePostProcessor.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include <utility>
 #include <unordered_set>
+#include <unordered_map>
 
 namespace genie {
 
@@ -78,9 +79,12 @@ namespace genie {
     SplinePostProcessor(std::string name, std::string config);
     ~SplinePostProcessor();
 
+    static SplinePostProcessor * Instance();
+
     //-- implement the SplinePostProcessorI interface
     std::vector<double> ProcessSpline(const std::vector<double> E,
-				      const std::vector<double> xsec) const;
+				      const std::vector<double> xsec,
+				      const int pdg) const;
 
     //-- override the Algorithm::Configure methods to load configuration
     //   data to private data members
@@ -94,10 +98,15 @@ namespace genie {
     //-- Check if we've enabled post-processing
     bool UsePostProcessing() const { return fUsePostProcessing; }
 
-    //-- Workhorse method
-    Spline * ProcessSpline( const Spline * spl ) const;
+    //-- Simple getter-setter machinery
+    std::vector<double> GetStops() const       { return  fStops;   }
+    void SetStops(std::vector<double> stops ) const { fStops  = stops;  }
+    std::vector<double> GetWidths() const      { return  fWidths;  }
+    void SetWidths(std::vector<double> widths) const { fWidths = widths; }
 
   private:
+
+    static SplinePostProcessor * fInstance;
 
     void Init       (void);
     void LoadConfig (void);
@@ -108,8 +117,15 @@ namespace genie {
     //-- private data members
     std::unordered_set<std::string> fAlgs; ///< Algorithms handled by the SplinePostProcessor. 
 
-    std::vector<double> fStops;  ///< Abscissae for the interpolation of the Gaussian kernel smoother
-    std::vector<double> fWidths; ///< Widths of the Gaussian kernel smoother at the stops
+    // Stops and widths to be used when processing a spline
+    mutable std::vector<double> fStops;  ///< Abscissae for the interpolation of the Gaussian kernel smoother
+    mutable std::vector<double> fWidths; ///< Widths of the Gaussian kernel smoother at the stops
+
+    // Map of the stops and widths to be used, potentially.
+    // If a key with "@PDG=.." is seen, add this PDG to the map.
+    // There is always a key "0" that is the default.
+    std::unordered_map<int, std::vector<double>> fStopMap;
+    std::unordered_map<int, std::vector<double>> fWidthMap;
 
     bool fUsePostProcessing; ///< If true, do post processing. If false, do nothing.
 

--- a/src/Framework/Numerical/SplinePostProcessor.h
+++ b/src/Framework/Numerical/SplinePostProcessor.h
@@ -91,6 +91,10 @@ namespace genie {
     bool IsHandled (std::string alg_name, std::string alg_config);
     bool IsHandled (const Algorithm * alg);
 
+    //-- Check if we've enabled post-processing
+    bool UsePostProcessing() const { return fUsePostProcessing; }
+
+    //-- Workhorse method
     Spline * ProcessSpline( const Spline * spl ) const;
 
   private:
@@ -106,6 +110,8 @@ namespace genie {
 
     std::vector<double> fStops;  ///< Abscissae for the interpolation of the Gaussian kernel smoother
     std::vector<double> fWidths; ///< Widths of the Gaussian kernel smoother at the stops
+
+    bool fUsePostProcessing; ///< If true, do post processing. If false, do nothing.
 
   }; // class SplinePostProcessor
 

--- a/src/Framework/Numerical/SplinePostProcessor.h
+++ b/src/Framework/Numerical/SplinePostProcessor.h
@@ -1,0 +1,114 @@
+//____________________________________________________________________________
+/*!
+
+\class   genie::SplinePostProcessor
+
+\brief   Post processor class to smooth out a Spline object.
+         This acts on the xsec values (not the abscissae, E) of each Spline
+	 by implementing a Gaussian kernel of variable width.
+
+	 The width of this kernel (in GeV) is user-configurable, and is linearly interpolated
+	 between stops. 
+	 See en.wikipedia.org/wiki/Kernel_smoother#Gaussian_kernel_smoother
+
+\author  John Plows <kplows \at liverpool.ac.uk>
+         University of Liverpool
+
+\created November 3, 2025
+
+\cpright Copyright (c) 2003-2025, The GENIE Collaboration
+         For the full text of the license visit 
+	 http://genie-mc.github.io/copyright.html
+*/
+//____________________________________________________________________________
+
+#ifndef _SPLINE_POST_PROCESSOR_H_
+#define _SPLINE_POST_PROCESSOR_H_
+
+#include "Framework/Numerical/SplinePostProcessorI.h"
+#include "Framework/Algorithm/AlgConfigPool.h"
+#include "Framework/Algorithm/AlgId.h"
+
+#include <iostream>
+#include <cmath>
+#include <vector>
+#include <utility>
+#include <unordered_set>
+
+namespace genie {
+
+  // Add an exception handler for spline post processing
+  // make it part of genie::exceptions
+  namespace exceptions {
+    class SplineProcessingException {
+
+    public:
+      SplineProcessingException();
+      SplineProcessingException(const SplineProcessingException & exception);
+      SplineProcessingException(std::string reason, bool interrupt = false);
+      ~SplineProcessingException();
+
+      void Init(void);
+      void Copy(const SplineProcessingException & exception);
+      void Print(std::ostream & stream) const;
+
+      void SetReason(std::string reason) { fReason = reason; }
+      void SetInterrupt(bool interrupt) { fInterrupt = interrupt; }
+      string ShowReason  (void) const { return fReason; }
+      bool   DoInterrupt (void) const { return fInterrupt; }
+
+      friend std::ostream & operator << ( std::ostream & stream, 
+					  const SplineProcessingException & exception );
+
+    private:
+
+      std::string fReason;
+      bool        fInterrupt;
+
+    }; // class genie::exceptions::SplineProcessingException
+  } // namespace exceptions
+
+  class Spline;
+
+  class SplinePostProcessor: public SplinePostProcessorI {
+
+  public:
+    SplinePostProcessor();
+    SplinePostProcessor(std::string name);
+    SplinePostProcessor(std::string name, std::string config);
+    ~SplinePostProcessor();
+
+    //-- implement the SplinePostProcessorI interface
+    std::vector<double> ProcessSpline(const std::vector<double> E,
+				      const std::vector<double> xsec) const;
+
+    //-- override the Algorithm::Configure methods to load configuration
+    //   data to private data members
+    void Configure (const Registry & config);
+    void Configure (std::string param_set);
+
+    //-- check if an algorithm is handled
+    bool IsHandled (std::string alg_name, std::string alg_config);
+    bool IsHandled (const Algorithm * alg);
+
+    Spline * ProcessSpline( const Spline * spl ) const;
+
+  private:
+
+    void Init       (void);
+    void LoadConfig (void);
+
+    void SetThresholds( std::vector<double> & stops, std::vector<double> & widths,
+			double xmin, double xmax ) const;
+
+    //-- private data members
+    std::unordered_set<std::string> fAlgs; ///< Algorithms handled by the SplinePostProcessor. 
+
+    std::vector<double> fStops;  ///< Abscissae for the interpolation of the Gaussian kernel smoother
+    std::vector<double> fWidths; ///< Widths of the Gaussian kernel smoother at the stops
+
+  }; // class SplinePostProcessor
+
+} // namespace genie
+
+#endif // #ifndef _SPLINE_POST_PROCESSOR_H_

--- a/src/Framework/Numerical/SplinePostProcessorI.cxx
+++ b/src/Framework/Numerical/SplinePostProcessorI.cxx
@@ -1,0 +1,38 @@
+//____________________________________________________________________________
+/*
+ Copyright (c) 2003-2025, The GENIE Collaboration
+ For the full text of the license visit http://copyright.genie-mc.org
+
+ John Plows <kplows \at liverpool.uk>
+ University of Liverpool
+*/
+//____________________________________________________________________________
+
+#include "Framework/Numerical/SplinePostProcessorI.h"
+
+using namespace genie;
+
+//____________________________________________________________________________
+SplinePostProcessorI::SplinePostProcessorI() :
+  Algorithm()
+{
+
+}
+//____________________________________________________________________________
+SplinePostProcessorI::SplinePostProcessorI(string name) :
+  Algorithm(name)
+{
+
+}
+//____________________________________________________________________________
+SplinePostProcessorI::SplinePostProcessorI(string name, string config) :
+  Algorithm(name, config)
+{
+
+}
+//____________________________________________________________________________
+SplinePostProcessorI::~SplinePostProcessorI()
+{
+
+}
+//____________________________________________________________________________

--- a/src/Framework/Numerical/SplinePostProcessorI.h
+++ b/src/Framework/Numerical/SplinePostProcessorI.h
@@ -1,0 +1,51 @@
+//____________________________________________________________________________
+/*!
+
+\class   genie::SplinePostProcessorI
+
+\brief   Interface for the SplinePostProcessor.
+         Concrete implementations of this interface use the 'Visitor' design
+	 to perform an operation on a Spline.
+
+\author  John Plows <kplows \at liverpool.ac.uk>
+         University of Liverpool
+
+\created October 29, 2025
+
+\cpright Copyright (c) 2003-2025, The GENIE Collaboration
+         For the full text of the license visit 
+	 http://genie-mc.github.io/copyright.html
+*/
+//____________________________________________________________________________
+
+#ifndef _SPLINE_POST_PROCESSOR_I_H_
+#define _SPLINE_POST_PROCESSOR_I_H_
+
+#include "Framework/Algorithm/Algorithm.h"
+
+namespace genie {
+
+  class Spline;
+
+  class SplinePostProcessorI : public Algorithm {
+
+  public:
+
+    virtual ~SplinePostProcessorI();
+
+    //-- define the SplinePostProcessorI interface
+
+    virtual std::vector<double> ProcessSpline(const std::vector<double> E,
+					      const std::vector<double> xsec) const = 0;
+
+  protected:
+
+    SplinePostProcessorI();
+    SplinePostProcessorI(string name);
+    SplinePostProcessorI(string name, string config);
+
+  }; // class SplinePostProcessorI
+
+} // namespace genie
+
+#endif // #ifndef _SPLINE_POST_PROCESSOR_I_H_

--- a/src/Framework/Numerical/SplinePostProcessorI.h
+++ b/src/Framework/Numerical/SplinePostProcessorI.h
@@ -36,7 +36,8 @@ namespace genie {
     //-- define the SplinePostProcessorI interface
 
     virtual std::vector<double> ProcessSpline(const std::vector<double> E,
-					      const std::vector<double> xsec) const = 0;
+					      const std::vector<double> xsec,
+					      const int pdg) const = 0;
 
   protected:
 

--- a/src/Framework/Utils/XSecSplineList.cxx
+++ b/src/Framework/Utils/XSecSplineList.cxx
@@ -57,7 +57,6 @@ XSecSplineList::XSecSplineList()
   fNKnots      = 100;
   fEmin        =   0.01; // GeV
   fEmax        = 100.00; // GeV
-  fPostProcessor = SplinePostProcessor();
 }
 //____________________________________________________________________________
 XSecSplineList::~XSecSplineList()
@@ -268,11 +267,13 @@ void XSecSplineList::CreateSpline(const XSecAlgorithmI * alg,
 
   }
 
+  fPostProcessor = *( SplinePostProcessor::Instance() );
   if( fPostProcessor.UsePostProcessing() ) {
     // Check if need to post-process
     if( fPostProcessor.IsHandled(alg) ) {
       SLOG("XSecSplList", pINFO) << "Post processing spline with key: " << key;
-      xsec = fPostProcessor.ProcessSpline(E, xsec);
+      xsec = fPostProcessor.ProcessSpline(E, xsec,
+					  interaction->InitStatePtr()->ProbePdg());
 
       // Output so the user can see the new spline
       for( size_t i = 0; i < E.size(); i++ ) {

--- a/src/Framework/Utils/XSecSplineList.cxx
+++ b/src/Framework/Utils/XSecSplineList.cxx
@@ -57,6 +57,7 @@ XSecSplineList::XSecSplineList()
   fNKnots      = 100;
   fEmin        =   0.01; // GeV
   fEmax        = 100.00; // GeV
+  fPostProcessor = SplinePostProcessor();
 }
 //____________________________________________________________________________
 XSecSplineList::~XSecSplineList()
@@ -267,18 +268,20 @@ void XSecSplineList::CreateSpline(const XSecAlgorithmI * alg,
 
   }
 
-  // Check if need to post-process
-  if( fPostProcessor.IsHandled(alg) ) {
-    SLOG("XSecSplList", pINFO) << "Post processing spline with key: " << key;
-    xsec = fPostProcessor.ProcessSpline(E, xsec);
+  if( fPostProcessor.UsePostProcessing() ) {
+    // Check if need to post-process
+    if( fPostProcessor.IsHandled(alg) ) {
+      SLOG("XSecSplList", pINFO) << "Post processing spline with key: " << key;
+      xsec = fPostProcessor.ProcessSpline(E, xsec);
 
-    // Output so the user can see the new spline
-    for( size_t i = 0; i < E.size(); i++ ) {
-      SLOG("XSecSplList", pNOTICE)
-	<< "xsec(E = " << E[i] << ") =  "
-	<< (1E+38/units::cm2)*xsec[i] << " x 1E-38 cm^2 post-smoothing";
-    }
-  }
+      // Output so the user can see the new spline
+      for( size_t i = 0; i < E.size(); i++ ) {
+	SLOG("XSecSplList", pNOTICE)
+	  << "xsec(E = " << E[i] << ") =  "
+	  << (1E+38/units::cm2)*xsec[i] << " x 1E-38 cm^2 post-processing";
+      } // output
+    } // if handled alg
+  } // if post processing
 
 
   // Warn about odd case of decreasing cross section

--- a/src/Framework/Utils/XSecSplineList.cxx
+++ b/src/Framework/Utils/XSecSplineList.cxx
@@ -267,6 +267,20 @@ void XSecSplineList::CreateSpline(const XSecAlgorithmI * alg,
 
   }
 
+  // Check if need to post-process
+  if( fPostProcessor.IsHandled(alg) ) {
+    SLOG("XSecSplList", pINFO) << "Post processing spline with key: " << key;
+    xsec = fPostProcessor.ProcessSpline(E, xsec);
+
+    // Output so the user can see the new spline
+    for( size_t i = 0; i < E.size(); i++ ) {
+      SLOG("XSecSplList", pNOTICE)
+	<< "xsec(E = " << E[i] << ") =  "
+	<< (1E+38/units::cm2)*xsec[i] << " x 1E-38 cm^2 post-smoothing";
+    }
+  }
+
+
   // Warn about odd case of decreasing cross section
   //    but allow for small variation due to integration errors
   const double eps_xsec = 1.0e-5;

--- a/src/Framework/Utils/XSecSplineList.h
+++ b/src/Framework/Utils/XSecSplineList.h
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "Framework/Conventions/XmlParserStatus.h"
+#include "Framework/Numerical/SplinePostProcessor.h"
 
 using std::map;
 using std::set;
@@ -38,6 +39,7 @@ namespace genie {
 class XSecAlgorithmI;
 class Interaction;
 class Spline;
+class SplinePostProcessor;
 
 class XSecSplineList;
 ostream & operator << (ostream & stream, const XSecSplineList & xsl);
@@ -97,6 +99,8 @@ private:
   virtual ~XSecSplineList();
 
   static XSecSplineList * fInstance;
+  
+  SplinePostProcessor fPostProcessor;
 
   bool   fUseLogE;
   int    fNKnots;


### PR DESCRIPTION
For the cross-section algorithms that rely on `NewQELXSec` to integrate, MC throws of the struck nucleon are required to compute the cross-section. This leads to a "jitter" in the graph of the cross-section as a function of neutrino energy.

This PR adds a new singleton class `genie::SplinePostProcessor`, that acts after spline knots have been collected in `XSecSplineList`, and applies a [Gaussian kernel smoother](https://en.wikipedia.org/wiki/Kernel_smoother#Gaussian_kernel_smoother) to the knots, "smoothing" the spline.

The `SplinePostProcessor` acts only on algorithms that it has been configured to run on (one can add these as keys in the `SplinePostProcessor.xml` file), and only if it has been switched on at the configuration. By default, the `SplinePostProcessor` is configured to act on `NievesQELCCPXSec/ZExp`.

One may specify a sequence of "stops", or reference energies, at which the width of the window is given by a corresponding entry in a sequence of "widths". In between "stops", the width is interpolated linearly.
One may also specify additional "stops" and "widths" per neutrino PDG; this is done by specifying the additional string `@Pdg=<probe PDG>` in the configuration key. In this XML file, a separate key is set for tau neutrinos, which have significantly higher thresholds than muon or electron neutrinos.

Some validation plots, in the form of "Brazil bands" follow: first, for 12C, 16O, and 40Ar, and for each of the (anti)neutrino flavours, one hundred runs of `gmkspl -e 10 -n 100` (using tune `AR23_20i_00_000`) were generated; for each of the spline xmls made, for each of the energies sampled, the 100 results for σ were collected into a distribution.

A band of (<σ> - 2υ, <σ> + 2υ) is coloured in yellow; a band of (<σ> - υ, <σ> + υ) is coloured in green, where <σ>, υ are the sample mean and variance of this distribution.
Then, a spline is generated, with the `SplinePostProcessor` switched off: this is plotted as red points. The jitter is evident, with a fraction of points lying outside the "2 sigma" yellow band.
Finally, a spline with the same seed is generated, with the `SplinePostProcessor` switched on, and plotted as the dashed blue line. The graph of the cross-section is both less "jittery", and now lies within the band, indicating a better agreement with the "expected" cross-section.
Shown here: numu on 40Ar, nue on 12C, nutau on 16O.

<img width="2596" height="3705" alt="40Ar_numu" src="https://github.com/user-attachments/assets/70247073-88d8-4e68-8408-b628d3663472" />
<img width="2581" height="3705" alt="12C_nue" src="https://github.com/user-attachments/assets/94239b3f-801c-4858-ba95-6d65b5aac40c" />
<img width="2581" height="3705" alt="16O_nutau" src="https://github.com/user-attachments/assets/705e8c08-14b4-46fa-8144-9fa7d76cd9f4" />
