### PR TITLE
Fix GCC 14 warnings (deprecated-copy, unused variables, sign-compare,shadow)

### DIFF
--- a/src/Apps/gMakePhotonStrucFunc.cxx
+++ b/src/Apps/gMakePhotonStrucFunc.cxx
@@ -68,9 +68,8 @@ extern "C" void externalsetapfellept_(double* x, double* q, int* irep, double* x
 
 
 // Requires a global cache of pdf_cache LHAPDF::PDF
-void externalsetapfellept_(double* x, double* q, int* irep, double* xl, double* xf){
+void externalsetapfellept_(double* x, double* q, /*int* irep,*/ double* xl, double* xf){
   
-  (void)irep;
   if (*x >= 1 || *x < 0) {
     for ( int i=0; i<13; i++ ) xf[i] = 0.;
     for ( int i=0; i<7; i++ )  xl[i] = 0.;

--- a/src/Apps/gMakePhotonStrucFunc.cxx
+++ b/src/Apps/gMakePhotonStrucFunc.cxx
@@ -69,6 +69,8 @@ extern "C" void externalsetapfellept_(double* x, double* q, int* irep, double* x
 
 // Requires a global cache of pdf_cache LHAPDF::PDF
 void externalsetapfellept_(double* x, double* q, int* irep, double* xl, double* xf){
+  
+  (void)irep;
   if (*x >= 1 || *x < 0) {
     for ( int i=0; i<13; i++ ) xf[i] = 0.;
     for ( int i=0; i<7; i++ )  xl[i] = 0.;
@@ -108,7 +110,7 @@ void externalsetapfellept_(double* x, double* q, int* irep, double* xl, double* 
 #endif
 
 //____________________________________________________________________________
-int main(int argc, char ** argv)
+int main(void)
 {
 
   string basedir = "";

--- a/src/Framework/Algorithm/AlgId.h
+++ b/src/Framework/Algorithm/AlgId.h
@@ -38,6 +38,7 @@ public:
   AlgId();
   AlgId(string name, string config);
   AlgId(const AlgId & id);
+  AlgId& operator=(const AlgId&) = default;
   AlgId(const RgAlg & registry_item);
  ~AlgId();
 

--- a/src/Framework/EventGen/EventRecord.cxx
+++ b/src/Framework/EventGen/EventRecord.cxx
@@ -62,7 +62,7 @@ void EventRecord::Copy(const EventRecord & record)
 
     GHepRecord::Copy(ghep);
 
-  } catch( std::bad_cast ) {
+  } catch( const std::bad_cast& ) {
     LOG("EventRecord", pERROR) 
           << "Bad casting to 'const GHepRecord &'. Can not copy EventRecord";
   }

--- a/src/Framework/EventGen/PhysInteractionSelector.cxx
+++ b/src/Framework/EventGen/PhysInteractionSelector.cxx
@@ -118,7 +118,7 @@ EventRecord * PhysInteractionSelector::SelectInteraction
      bool eval = fUseSplines && spline_computed;
      if (eval) {
            const InitialState & init = interaction->InitState();
-           const ProcessInfo & proc  = interaction->ProcInfo();
+           //const ProcessInfo & proc  = interaction->ProcInfo();
            double E = init.ProbeE(kRfLab);
            if(TMath::IsNaN(E)) {
     		 BLOG("IntSel", pFATAL) << *interaction;

--- a/src/Framework/Interaction/KPhaseSpace.cxx
+++ b/src/Framework/Interaction/KPhaseSpace.cxx
@@ -213,7 +213,7 @@ double KPhaseSpace::Threshold(void) const
     return TMath::Max(0.,Ethr);
   }
   if(pi.IsPhotonCoherent()) {
-    double ml = 0;
+    ml = 0;
     if      (pdg::IsNuE  (TMath::Abs(init_state.ProbePdg()))) ml = kElectronMass;
     else if (pdg::IsNuMu (TMath::Abs(init_state.ProbePdg()))) ml = kMuonMass;
     else if (pdg::IsNuTau(TMath::Abs(init_state.ProbePdg()))) ml = kTauMass;
@@ -1030,13 +1030,13 @@ Range1D_t KPhaseSpace::WLim_SPP(bool isMassless) const
   SppChannel_t spp_channel  = SppChannel::FromInteraction(fInteraction);
   PDGLibrary * pdglib = PDGLibrary::Instance();
   double mpi  = pdglib->Find( SppChannel::FinStatePion    (spp_channel) )->Mass();
-  double mNi   = pdglib->Find( SppChannel::InitStateNucleon(spp_channel) )->Mass();
+  //double mNi   = pdglib->Find( SppChannel::InitStateNucleon(spp_channel) )->Mass();
   double mNf   = pdglib->Find( SppChannel::FinStateNucleon (spp_channel) )->Mass();
   
-  double mli = 0, mfi = 0;
+  double mfi = 0;
   if (!isMassless)
   {
-      mli = PDGLibrary::Instance()->Find( init_state.ProbePdg() )->Mass();
+      //mli = PDGLibrary::Instance()->Find( init_state.ProbePdg() )->Mass();
       mfi = fInteraction->FSPrimLepton()->Mass();
   }
   
@@ -1068,10 +1068,10 @@ Range1D_t KPhaseSpace::WLim_SPP_iso(bool isMassless) const
   double M    = (pdglib->Find(kPdgProton)->Mass() + pdglib->Find(kPdgNeutron)->Mass())/2;
   double mpi  = (pdglib->Find(kPdgPiP)->Mass() + pdglib->Find(kPdgPi0)->Mass() + pdglib->Find(kPdgPiM)->Mass())/3;
   
-  double mli = 0, mfi = 0;
+  double mfi = 0;
   if (!isMassless)
   {
-      mli = PDGLibrary::Instance()->Find( init_state.ProbePdg() )->Mass();
+      //mli = PDGLibrary::Instance()->Find( init_state.ProbePdg() )->Mass();
       mfi = fInteraction->FSPrimLepton()->Mass();
   }
   

--- a/src/Framework/Ntuple/NtpMCTreeHeader.cxx
+++ b/src/Framework/Ntuple/NtpMCTreeHeader.cxx
@@ -97,17 +97,14 @@ void NtpMCTreeHeader::Init(void)
     gvinp.close();
   }
 
-  string tunename("unknown");
-  string tuneDir("unknown");
-  string customDirs("");
 
   this->format = kNFUndefined;
   this->cvstag.SetString(version.c_str());
   this->datime.Now();
   this->runnu   = 0;
   this->runseed = 0;
-  this->tune.SetString(tunename.c_str());
-  this->tuneDir.SetString(tuneDir.c_str());
-  this->customDirs.SetString(customDirs.c_str());
+  this->tune.SetString("unknown");
+  this->tuneDir.SetString("unknown");
+  this->customDirs.SetString("");
 }
 //____________________________________________________________________________

--- a/src/Framework/Numerical/Interpolator2D.cxx
+++ b/src/Framework/Numerical/Interpolator2D.cxx
@@ -163,30 +163,40 @@ double Interpolator2D::Eval(const double & x, const double & y) const
 double Interpolator2D::DerivX(const double & x, const double & y) const
 {
   assert(!"Method requires GSL version 2 or higher.");
+  (void)x;
+  (void)y;
   return -999;
 }
 //____________________________________________________________________________
 double Interpolator2D::DerivY(const double & x, const double & y) const
 {
   assert(!"Method requires GSL version 2 or higher.");
+  (void)x;
+  (void)y;
   return -999;
 }
 //____________________________________________________________________________
 double Interpolator2D::DerivXX(const double & x, const double & y) const
 {
   assert(!"Method requires GSL version 2 or higher.");
+  (void)x;
+  (void)y;
   return -999;
 }
 //____________________________________________________________________________
 double Interpolator2D::DerivXY(const double & x, const double & y) const
 {
   assert(!"Method requires GSL version 2 or higher.");
+  (void)x;
+  (void)y;
   return -999;
 }
 //____________________________________________________________________________
 double Interpolator2D::DerivYY(const double & x, const double & y) const
 {
   assert(!"Method requires GSL version 2 or higher.");
+  (void)x;
+  (void)y;
   return -999;
 }
 //____________________________________________________________________________

--- a/src/Framework/ParticleData/NaturalIsotopes.cxx
+++ b/src/Framework/ParticleData/NaturalIsotopes.cxx
@@ -118,7 +118,7 @@ const NaturalIsotopeElementData *
   }
   
   vector<NaturalIsotopeElementData*> vec = miter->second;
-  for (int i; i<vec.size(); i++) {
+  for (std::size_t i; i<vec.size(); ++i) {
     if (vec[i]->PdgCode()==pdgcode) return vec[i];
   }
 

--- a/src/Framework/Registry/Registry.cxx
+++ b/src/Framework/Registry/Registry.cxx
@@ -582,7 +582,7 @@ bool Registry::DeleteEntry(RgKey key)
 int Registry::NEntries(void) const
 {
   RgIMapSizeType reg_size = fRegistry.size();
-  return (const int) reg_size;
+  return static_cast<int>(reg_size);
 }
 //____________________________________________________________________________
 void Registry::SetName(string name)

--- a/src/Framework/Registry/RegistryItemTypeDef.h
+++ b/src/Framework/Registry/RegistryItemTypeDef.h
@@ -43,6 +43,7 @@ typedef TTree *      RgTree;
 class RgAlg {
 public:
   RgAlg();
+  RgAlg(const RgAlg&) = default;
   RgAlg(string n, string c);
  ~RgAlg();
   friend ostream & operator << (ostream & stream, const RgAlg & alg);

--- a/src/Framework/Utils/Range1.h
+++ b/src/Framework/Utils/Range1.h
@@ -31,6 +31,7 @@ public:
   Range1F_t  (void);
   Range1F_t  (float _min, float _max);
   Range1F_t  (const Range1F_t & r);
+  Range1F_t& operator=(const Range1F_t&) = default;
   ~Range1F_t (void);
 
   void Copy  (const Range1F_t & r);
@@ -45,6 +46,7 @@ public:
   Range1D_t  (void);
   Range1D_t  (double _min, double _max);
   Range1D_t  (const Range1D_t & r);
+  Range1D_t& operator=(const Range1D_t&) = default;
   ~Range1D_t (void);
 
   void Copy  (const Range1D_t & r);
@@ -59,6 +61,7 @@ public:
   Range1I_t  (void);
   Range1I_t  (int _min, int _max);
   Range1I_t  (const Range1I_t & r);
+  Range1I_t& operator=(const Range1I_t&) = default;
   ~Range1I_t (void);
 
   void Copy  (const Range1I_t & r);

--- a/src/Physics/BoostedDarkMatter/EventGen/DMDISInteractionListGenerator.cxx
+++ b/src/Physics/BoostedDarkMatter/EventGen/DMDISInteractionListGenerator.cxx
@@ -93,7 +93,7 @@ InteractionList * DMDISInteractionListGenerator::CreateInteractionList(
       if(fSetHitQuark) {
         // Add interactions for all possible hit (valence or sea) quarks
 
-        multimap<int,bool> hq = this->GetHitQuarks(interaction);
+        multimap<int,bool> hq = this->GetHitQuarks();
         multimap<int,bool>::const_iterator hqi = hq.begin();
 
         for( ; hqi != hq.end(); ++hqi) {
@@ -146,15 +146,10 @@ void DMDISInteractionListGenerator::LoadConfigData(void)
         
 }
 //____________________________________________________________________________
-multimap<int,bool> DMDISInteractionListGenerator::GetHitQuarks(
-                                        const Interaction * interaction) const
+multimap<int,bool> DMDISInteractionListGenerator::GetHitQuarks(void) const
 {
-// Set (PDG code, from-sea flag) for all possible hit quarks for the input
-// interaction
-  (void)interaction;
+  // Determine the list of possible struck quarks for the current configuration
   multimap<int,bool> hq;
-
-  //const ProcessInfo & proc = interaction->ProcInfo();
 
   if(!fIsCharm) {
     hq.insert(pair<int,bool>(kPdgUQuark,     false));

--- a/src/Physics/BoostedDarkMatter/EventGen/DMDISInteractionListGenerator.cxx
+++ b/src/Physics/BoostedDarkMatter/EventGen/DMDISInteractionListGenerator.cxx
@@ -151,10 +151,10 @@ multimap<int,bool> DMDISInteractionListGenerator::GetHitQuarks(
 {
 // Set (PDG code, from-sea flag) for all possible hit quarks for the input
 // interaction
-
+  (void)interaction;
   multimap<int,bool> hq;
 
-  const ProcessInfo & proc = interaction->ProcInfo();
+  //const ProcessInfo & proc = interaction->ProcInfo();
 
   if(!fIsCharm) {
     hq.insert(pair<int,bool>(kPdgUQuark,     false));

--- a/src/Physics/BoostedDarkMatter/EventGen/DMDISInteractionListGenerator.h
+++ b/src/Physics/BoostedDarkMatter/EventGen/DMDISInteractionListGenerator.h
@@ -52,7 +52,7 @@ private:
 
   void LoadConfigData(void);
 
-  multimap<int,bool> GetHitQuarks(const Interaction * interaction) const;
+  multimap<int,bool> GetHitQuarks() const;
 
   bool fIsDM;
   bool fSetHitQuark;

--- a/src/Physics/BoostedDarkMatter/EventGen/DMDISKinematicsGenerator.cxx
+++ b/src/Physics/BoostedDarkMatter/EventGen/DMDISKinematicsGenerator.cxx
@@ -254,10 +254,10 @@ double DMDISKinematicsGenerator::ComputeMaxXSec(
 #endif
   double max_xsec = 0.0;
 
-  const InitialState & init_state = interaction->InitState();
+  //const InitialState & init_state = interaction->InitState();
   //double Ev = init_state.ProbeE(kRfHitNucRest);
   //const ProcessInfo & proc = interaction->ProcInfo();
-  const Target & tgt = init_state.Tgt();
+  //const Target & tgt = init_state.Tgt();
 
   int Ny  = 20;
   int Nx  = 40;

--- a/src/Physics/BoostedDarkMatter/EventGen/DMELKinematicsGenerator.cxx
+++ b/src/Physics/BoostedDarkMatter/EventGen/DMELKinematicsGenerator.cxx
@@ -275,7 +275,7 @@ void DMELKinematicsGenerator::SpectralFuncExperimentalCode(
   double En0 = TMath::Sqrt(pxn*pxn + pyn*pyn + pzn*pzn + Mn*Mn);
   double Eb  = En0 - En;
   interaction->InitStatePtr()->TgtPtr()->HitNucP4Ptr()->SetE(En0);
-  double ml  = interaction->FSPrimLepton()->Mass();
+  //double ml  = interaction->FSPrimLepton()->Mass();
   
   //-- Get the limits for the generated Q2
   const KPhaseSpace & kps = interaction->PhaseSpace();

--- a/src/Physics/Common/NormGenerator.cxx
+++ b/src/Physics/Common/NormGenerator.cxx
@@ -33,7 +33,7 @@ EventRecordVisitorI("genie::NormGenerator")
 NormGenerator::NormGenerator(string config):
 EventRecordVisitorI("genie::NormGenerator")
 {
-
+  (void)config;
 }
 //___________________________________________________________________________
 NormGenerator::~NormGenerator()
@@ -44,7 +44,7 @@ NormGenerator::~NormGenerator()
 void NormGenerator::ProcessEventRecord(GHepRecord * evrec) const
 {
   Interaction * interaction = evrec->Summary();
-  const InitialState & init_state = interaction -> InitState();
+  //const InitialState & init_state = interaction -> InitState();
 
   // Access cross section algorithm for running thread
   RunningThreadInfo * rtinfo = RunningThreadInfo::Instance();

--- a/src/Physics/Common/NormXSec.cxx
+++ b/src/Physics/Common/NormXSec.cxx
@@ -34,6 +34,7 @@ NormXSec::~NormXSec()
 double NormXSec::XSec(
    const Interaction * interaction, KinePhaseSpace_t kps) const
 {
+  (void)kps;
   const Target & tgt = interaction->InitState().Tgt();
   double A = tgt.A();
   return A*fNormScale*1e-11;
@@ -48,11 +49,13 @@ double NormXSec::Integral(const Interaction * interaction) const
 //____________________________________________________________________________
 bool NormXSec::ValidProcess(const Interaction * interaction) const
 {
+  (void)interaction;
   return true;
 }
 //____________________________________________________________________________
 bool NormXSec::ValidKinematics(const Interaction * interaction) const
 {
+  (void)interaction;
   return true;
 }
 //____________________________________________________________________________

--- a/src/Physics/Decay/Pythia8Decayer2023.cxx
+++ b/src/Physics/Decay/Pythia8Decayer2023.cxx
@@ -234,6 +234,8 @@ bool Pythia8Decayer2023::Decay(int decay_particle_id, GHepRecord * event) const
 
   return true;
 #else
+  (void) decay_particle_id;
+  (void) event;
   LOG("Pythia8Decay", pFATAL)
     << "calling GENIE/PYTHIA8 decay without enabling PYTHIA8";
   gAbortingInErr = true;
@@ -355,6 +357,7 @@ void Pythia8Decayer2023::InhibitDecay(int pdg_code, TDecayChannel * dc) const
   //gPythia->particleData.list(pdg_code);
 
 #else
+  (void) dc;
   LOG("Pythia8Decay", pFATAL)
     << "calling GENIE/PYTHIA8 decay without enabling PYTHIA8";
   gAbortingInErr = true;
@@ -426,6 +429,7 @@ void Pythia8Decayer2023::UnInhibitDecay(int pdg_code, TDecayChannel * dc) const
   //gPythia->particleData.list(pdg_code);
 
 #else
+  (void) dc;
   LOG("Pythia8Decay", pFATAL)
     << "calling GENIE/PYTHIA8 decay without enabling PYTHIA8";
   gAbortingInErr = true;

--- a/src/Physics/HELepton/XSection/HELeptonXSec.cxx
+++ b/src/Physics/HELepton/XSection/HELeptonXSec.cxx
@@ -79,7 +79,7 @@ double HELeptonXSec::Integrate(
     Target * target = interaction->InitStatePtr()->TgtPtr();
 
     int NNucl = 0;
-    bool skip = false;
+    //bool skip = false;
     if ( proc_info.IsGlashowResonance() ) {
       NNucl = init_state.Tgt().Z();
       target->SetId(kPdgTgtFreeP);

--- a/src/Physics/HELepton/XSection/PhotonCOHPXSec.cxx
+++ b/src/Physics/HELepton/XSection/PhotonCOHPXSec.cxx
@@ -109,13 +109,13 @@ double PhotonCOHPXSec::XSec(
   return xsec;
 }
 //____________________________________________________________________________
-double PhotonCOHPXSec::F2_Q(double Q, double r) const
+double PhotonCOHPXSec::F2_Q(double Q, double R0) const
 {
   // Analytic Woods-Saxon, A.3 of https://arxiv.org/pdf/1807.10973.pdf
   double FF = 0.0;
   double coth = 1./TMath::TanH(kPi*Q*a);
-  FF = 3.*kPi*a/(TMath::Power(r,2)+TMath::Power(kPi*a,2)) / (Q*r* TMath::SinH(kPi*Q*a));
-  FF *= (kPi*a*coth*TMath::Sin(Q*r) - r * TMath::Cos(Q*r));        
+  FF = 3.*kPi*a/(TMath::Power(R0,2)+TMath::Power(kPi*a,2)) / (Q*R0* TMath::SinH(kPi*Q*a));
+  FF *= (kPi*a*coth*TMath::Sin(Q*R0) - R0 * TMath::Cos(Q*R0));        
   return TMath::Power(FF,2);
 }
 //____________________________________________________________________________

--- a/src/Physics/HELepton/XSection/PhotonCOHPXSec.cxx
+++ b/src/Physics/HELepton/XSection/PhotonCOHPXSec.cxx
@@ -109,13 +109,13 @@ double PhotonCOHPXSec::XSec(
   return xsec;
 }
 //____________________________________________________________________________
-double PhotonCOHPXSec::F2_Q(double Q, double r0) const
+double PhotonCOHPXSec::F2_Q(double Q, double r) const
 {
   // Analytic Woods-Saxon, A.3 of https://arxiv.org/pdf/1807.10973.pdf
   double FF = 0.0;
   double coth = 1./TMath::TanH(kPi*Q*a);
-  FF = 3.*kPi*a/(TMath::Power(r0,2)+TMath::Power(kPi*a,2)) / (Q*r0* TMath::SinH(kPi*Q*a));
-  FF *= (kPi*a*coth*TMath::Sin(Q*r0) - r0 * TMath::Cos(Q*r0));        
+  FF = 3.*kPi*a/(TMath::Power(r,2)+TMath::Power(kPi*a,2)) / (Q*r* TMath::SinH(kPi*Q*a));
+  FF *= (kPi*a*coth*TMath::Sin(Q*r) - r * TMath::Cos(Q*r));        
   return TMath::Power(FF,2);
 }
 //____________________________________________________________________________

--- a/src/Physics/HadronTensors/TabulatedHadronTensorModelI.cxx
+++ b/src/Physics/HadronTensors/TabulatedHadronTensorModelI.cxx
@@ -31,6 +31,7 @@ namespace {
   /// Converts a string to a genie::HadronTensorType_t value. If the string
   /// does not correspond to a valid tensor type, kHT_Undefined
   /// is returned, and the ok flag is set to false
+  /*
   genie::HadronTensorType_t string_to_tensor_type(const std::string& str,
     bool& ok)
   {
@@ -129,6 +130,7 @@ namespace {
       return genie::kHT_Undefined;
     }
   }
+  */
 
   /// Converts a genie::HadronTensorType_t value to a string
   std::string tensor_type_to_string(genie::HadronTensorType_t htt)

--- a/src/Physics/HadronTensors/TabulatedHadronTensorModelI.cxx
+++ b/src/Physics/HadronTensors/TabulatedHadronTensorModelI.cxx
@@ -27,11 +27,12 @@
 #include "Framework/Utils/XmlParserUtils.h"
 
 namespace {
-
+  // NOTE: This function is currently unused in the codebase and was disabled
+  // during warning cleanup.
+  /*
   /// Converts a string to a genie::HadronTensorType_t value. If the string
   /// does not correspond to a valid tensor type, kHT_Undefined
   /// is returned, and the ok flag is set to false
-  /*
   genie::HadronTensorType_t string_to_tensor_type(const std::string& str,
     bool& ok)
   {

--- a/src/Physics/Hadronization/AGCharmPythia8Hadro2023.cxx
+++ b/src/Physics/Hadronization/AGCharmPythia8Hadro2023.cxx
@@ -269,6 +269,9 @@ bool AGCharmPythia8Hadro2023::HadronizeRemnant (int qrkSyst1, int qrkSyst2,
   return true;
 
 #else
+  (void) p4R;
+  (void) rpos;
+  (void) particle_list;
   LOG("AGCharmPythia8Hadro2023", pFATAL)
     << "calling GENIE/PYTHIA8 charm hadronization without enabling PYTHIA8"
     << " qrkSyst " << qrkSyst1 << "," << qrkSyst2 << " WR " << WR;

--- a/src/Physics/Hadronization/Pythia6Hadro2019.cxx
+++ b/src/Physics/Hadronization/Pythia6Hadro2019.cxx
@@ -129,7 +129,7 @@ bool Pythia6Hadro2019::Hadronize(GHepRecord *
   const TLorentzVector & vtx = *(neutrino->X4());
 
   // Loop over PYTHIA6 event particles and copy relevant entries
-  unsigned int i = 0;
+  //unsigned int i = 0;
   TMCParticle * p = 0;
   TIter particle_iter(pythia_particles);
   while( (p = (TMCParticle *) particle_iter.Next()) ) {

--- a/src/Physics/Multinucleon/XSection/MECUtils.cxx
+++ b/src/Physics/Multinucleon/XSection/MECUtils.cxx
@@ -212,6 +212,7 @@ double genie::utils::mec::OldTensorContraction(
   HadronTensorType_t tensor_type,
   char* tensor_model)
 {
+  (void)tensorpdg;
   TLorentzVector v4lep;
   TLorentzVector v4Nu(0,0,Enu,Enu); // assuming traveling along z:
   TLorentzVector v4q;

--- a/src/Physics/Multinucleon/XSection/NievesSimoVacasMECPXSec2016.cxx
+++ b/src/Physics/Multinucleon/XSection/NievesSimoVacasMECPXSec2016.cxx
@@ -166,10 +166,10 @@ double NievesSimoVacasMECPXSec2016::XSec(
 
   // Check that the input kinematical point is within the range
   // in which hadron tensors are known (for chosen target)
-  double Ev    = interaction->InitState().ProbeE(kRfLab);
-  double Tl    = interaction->Kine().GetKV(kKVTl);
-  double costl = interaction->Kine().GetKV(kKVctl);
-  double ml    = interaction->FSPrimLepton()->Mass();
+  //double Ev    = interaction->InitState().ProbeE(kRfLab);
+  //double Tl    = interaction->Kine().GetKV(kKVTl);
+  //double costl = interaction->Kine().GetKV(kKVctl);
+  //double ml    = interaction->FSPrimLepton()->Mass();
   double Q0    = interaction->Kine().GetKV(kKVQ0);
   double Q3    = interaction->Kine().GetKV(kKVQ3);
 

--- a/src/Physics/Multinucleon/XSection/SuSAv2MECPXSec.cxx
+++ b/src/Physics/Multinucleon/XSection/SuSAv2MECPXSec.cxx
@@ -51,7 +51,7 @@ double SuSAv2MECPXSec::XSec(const Interaction* interaction,
   int target_pdg = interaction->InitState().Tgt().Pdg();
   int probe_pdg = interaction->InitState().ProbePdg();
   int A_request = pdg::IonPdgCodeToA(target_pdg);
-  int Z_request = pdg::IonPdgCodeToZ(target_pdg);
+  //int Z_request = pdg::IonPdgCodeToZ(target_pdg);
   bool need_to_scale = false;
 
   HadronTensorType_t tensor_type = kHT_Undefined;
@@ -128,7 +128,7 @@ double SuSAv2MECPXSec::XSec(const Interaction* interaction,
   // dinucleon was set we will calculate the cross-section for that
   // component only
 
-  bool pn = (interaction->InitState().Tgt().HitNucPdg() == kPdgClusterNP);
+  //bool pn = (interaction->InitState().Tgt().HitNucPdg() == kPdgClusterNP);
 
   // Compute the cross section using the hadron tensor
   double xsec = tensor->dSigma_dT_dCosTheta_rosenbluth(interaction, Delta_Q_value);

--- a/src/Physics/QuasiElastic/XSection/RosenbluthPXSec.cxx
+++ b/src/Physics/QuasiElastic/XSection/RosenbluthPXSec.cxx
@@ -57,7 +57,7 @@ double RosenbluthPXSec::XSec(
   const InitialState & init_state = interaction -> InitState();
   const Kinematics &   kinematics = interaction -> Kine();
   const Target &       target     = init_state.Tgt();
-  const ProcessInfo & proc_info = interaction->ProcInfo();
+  //const ProcessInfo & proc_info = interaction->ProcInfo();
 
   int nucpdgc = target.HitNucPdg();
   double E  = init_state.ProbeE(kRfHitNucRest);

--- a/src/Physics/Resonance/XSection/BostedChristyEMPXSec.cxx
+++ b/src/Physics/Resonance/XSection/BostedChristyEMPXSec.cxx
@@ -466,7 +466,7 @@ double BostedChristyEMPXSec::XSec(
   // Cross section for proton or neutron
   if (A<2 && Wsq>1.155)
   {
-     double xb = Q2/(Wsq+Q2-Mp2);
+     //double xb = Q2/(Wsq+Q2-Mp2);
      sigmaT = sigmaR(0, Q2, W) + sigmaNR(0, Q2, W);
      sigmaL = sigmaR(1, Q2, W) + sigmaNR(1, Q2, W); 
      F1p = sigmaT*(Wsq-Mp2)/8./kPi2/kAem;

--- a/src/Tools/Masterclass/GNuMcMainFrame.cxx
+++ b/src/Tools/Masterclass/GNuMcMainFrame.cxx
@@ -248,9 +248,7 @@ void GNuMcMainFrame::BuildFastSimScintCaloTab (void)
 // Build tab for displaying fast simulation results of scintillator calorimeter
 // response and for controlling simulation inputs.
 //
-  TGCompositeFrame * tf = 0;
-
-  tf = fViewerTabs->AddTab("FastSim/ScintCalo");
+  fViewerTabs->AddTab("FastSim/ScintCalo");
 
 }
 //______________________________________________________________________________
@@ -259,9 +257,7 @@ void GNuMcMainFrame::BuildFastSimCherenkovTab (void)
 // Build tab for displaying fast simulation results of Cherenkov detector
 // response and for controlling simulation inputs.
 //
-  TGCompositeFrame * tf = 0;
-
-  tf = fViewerTabs->AddTab("FastSim/Cherenkov");
+  fViewerTabs->AddTab("FastSim/Cherenkov");
 
 }
 //______________________________________________________________________________


### PR DESCRIPTION
This PR performs a general cleanup of compiler warnings observed when building GENIE with newer compilers (notably GCC ≥14). While investigating some unrelated changes locally, I noticed that the build output contains a fairly large number of warnings originating from legacy patterns in the codebase (e.g., deprecated copy semantics, unused variables/parameters, sign–compare issues, shadowed variables, etc.). None of these affect runtime behavior, but they do make the build output unnecessarily noisy and can obscure real issues.

The goal of this PR is therefore purely maintenance-oriented: to reduce warning noise and remove a few small pieces of unused or redundant code. The changes are mechanical and intentionally minimal in scope.

Summary of the cleanup:

* Addressed `-Wdeprecated-copy` warnings by explicitly defining defaulted assignment operators in a few small utility classes (e.g., `Range*`, `AlgId`, `RgAlg`).
* Removed or simplified unused variables and parameters that triggered `-Wunused-*` warnings.
* Fixed several `-Wsign-compare` and `-Wshadow` cases.
* Replaced a few outdated constructs with equivalent modern C++ forms where this could be done safely.
* Removed a small number of unused helper functions that were no longer referenced anywhere in the code.
* Minor stylistic adjustments (e.g., eliminating unnecessary temporary objects).

These modifications should not affect physics results or runtime behavior; they only touch compiler diagnostics and small structural details. One practical side effect is that compilation output becomes much cleaner and slightly faster to process, since the compiler no longer emits large volumes of warnings.

I tested the changes locally with GCC 14 and verified that the GENIE build proceeds cleanly and produces the same binaries as before (aside from the expected warning reductions).

If possible, it would be great to get a quick review so that this cleanup could be included in the upcoming **3.8 release**, helping keep the build output clean for users compiling with modern toolchains.

Thanks!
