### PR TITLE
Enable pythia8 selective channel on/off

### DIFF
--- a/config/CommonDecay.xml
+++ b/config/CommonDecay.xml
@@ -112,20 +112,50 @@ University of Liverpool
      <param type="bool" name="DecayParticleWithCode=202228"> true  </param>  <!-- F37(1950) Delta++  -->
      <param type="bool" name="DecayParticleWithCode=212112"> true  </param>  <!-- P11(1710) N0       -->
      <param type="bool" name="DecayParticleWithCode=212212"> true  </param>  <!-- P11(1710) N+       -->
-     <param type="bool" name="DecayParticleWithCode=212118"> true  </param>  <!-- F17(1970) N0       --> 
-     <param type="bool" name="DecayParticleWithCode=212218"> true  </param>  <!-- F17(1970) N+       --> 
+     <param type="bool" name="DecayParticleWithCode=212118"> true  </param>  <!-- F17(1970) N0       -->
+     <param type="bool" name="DecayParticleWithCode=212218"> true  </param>  <!-- F17(1970) N+       -->
      <param type="bool" name="DecayParticleWithCode=-24">   false </param>  <!-- W- from Glashow Resonance reactions -->
 
      <!--
 	    For particles to be decayed, all decay channels are open.
-	    To inhibit specific decay channels use as many of following configuration options as is needed
-	    specifying the particle PDG code and the inhibited TDecayChannel id.
-	    To print out the decay channel ids for any particle, use $GENIE/src/contrib/misc/print_decay_channel.C
+	    To (un)inhibit specific decay channels use as many of following configuration options as is
+	    needed specifying the particle PDG code and the inhibited ROOT's TDecayChannel id associated
+	    with PDGLibrary (which uses ROOT's TDatabasePDG underneath)
+	    To print out the decay channel ids for any particle, use
+	        $GENIE/src/contrib/misc/print_decay_channel.C
 
-	    <param type="bool" name="InhibitDecay/Particle=15,Channel=0"> true </param>
-	    <param type="bool" name="InhibitDecay/Particle=15,Channel=1"> true </param>
+	    <param type="bool" name="InhibitDecay/Particle=15,Channel=0">  true  </param>
+	    <param type="bool" name="InhibitDecay/Particle=15,Channel=1">  true  </param>
+	    <param type="bool" name="InhibitDecay/Particle=15,Channel=2">  false </param>
+	    <param type="bool" name="InhibitDecay/Particle=15,Channel=12"> false </param>
+	    <param type="bool" name="InhibitDecay/Particle=-15,Channel=0">  true  </param>
+	    <param type="bool" name="InhibitDecay/Particle=-15,Channel=1">  false  </param>
+	    <param type="bool" name="InhibitDecay/Particle=-15,Channel=2">  true  </param>
+	    <param type="bool" name="InhibitDecay/Particle=-15,Channel=12"> false </param>
 	    ...
 	    ...
+            IMPORTANT NOTE: the PDGLibrary (TDatabasePDG) is typically populated from
+                $GENIE/data/evgen/catalogues/pdg/genie_pdg_table.txt
+            while Pythia8 gets its particle information from $PYTHIA8DATA/ParticleData.xml
+            These (often) do _not_ match up in various ways.   In particular the list of decay channels
+            from PDGLibrary to Pythia8 is not 1-to-1.  What this means is that there are some channels
+            one can attempt to access via "InhibitDecay" that won't affect Pythia8, and there are some
+            Pythia8 decay channels that can't be manipulated via "InhibitDecay".  For some combinations
+            it might be more productive to turn _off_ all decays, and then turn on selected channels or
+            vice versa.
+            In particular for the tau the GENIE table has 53 channels, of which only 16 can be mapped to
+            one of Pythia8's 37 decay channels.  Take note of WARN messages that might indicate a missing map.
+
+            For Pythia8 one can use also use:
+                <param type="bool" name="PrintParticleDecayChannels=15"> true </param>
+            to print out the mapping for a particular particle.  This will print the
+            PDGLibrary view and a Pythia8 view of the decay channels.
+            For Pythia8 the "onMode" values mean:
+               0: decay channel is off
+               1: decay channel is on for both particle and antiparticle
+               2: on  for particle / off for antiparticle (if p=pbar acts as "on" )
+               3: off for particle / on  for antiparticle (if p=pbar acts as "off")
+
      -->
   </param_set>
 

--- a/src/Physics/Decay/Decayer.cxx
+++ b/src/Physics/Decay/Decayer.cxx
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <typeinfo>
 
 #include <TParticlePDG.h>
 
@@ -172,20 +173,20 @@ void Decayer::LoadConfig(void)
     int pdgc = atoi(kv[1].c_str());
     TParticlePDG * p = PDGLibrary::Instance()->Find(pdgc);
     if ( ! p ) {
-      LOG("Decay",pFATAL) << "No PDGLibrary entry for pdgc=" << pdgc
-                          << " (" << kv[1].c_str()
-                          << "), check CommonDecay.xml";
+      LOG("Decay",pFATAL)
+        << "DecayPaticleWithCode: no PDGLibrary entry for pdgc=" << pdgc
+        << " (" << kv[1].c_str() << "), check CommonDecay.xml";
       continue;
     }
     if(decay) {
        LOG("Decay", pDEBUG)
-            << "Configured to decay " <<  p->GetName();
+            << "Configured to uninhibit all decays for " <<  p->GetName();
        fParticlesToDecay.push_back(pdgc);
        this->UnInhibitDecay(pdgc);
     }
     else {
        LOG("Decay", pDEBUG)
-            << "Configured to inhibit decays for  " <<  p->GetName();
+            << "Configured to inhibit all decays for  " <<  p->GetName();
        fParticlesNotToDecay.push_back(pdgc);
        this->InhibitDecay(pdgc);
     }// decay?
@@ -197,19 +198,31 @@ void Decayer::LoadConfig(void)
   kiter = klist.begin();
   for( ; kiter != klist.end(); ++kiter) {
     RgKey key = *kiter;
-    if(GetConfig().GetBool(key)) {
-      string filtkey = utils::str::FilterString("InhibitDecay/", key);
-      vector<string> kv = utils::str::Split(filtkey,",");
-      assert(kv.size()==2);
-      int pdgc = atoi(utils::str::FilterString("Particle=",kv[0]).c_str());
-      int dc   = atoi(utils::str::FilterString("Channel=", kv[1]).c_str());
-      TParticlePDG * p = PDGLibrary::Instance()->Find(pdgc);
-      if(!p) continue;
+    string filtkey = utils::str::FilterString("InhibitDecay/", key);
+    vector<string> kv = utils::str::Split(filtkey,",");
+    assert(kv.size()==2);
+    int pdgc = atoi(utils::str::FilterString("Particle=",kv[0]).c_str());
+    int dc   = atoi(utils::str::FilterString("Channel=", kv[1]).c_str());
+    TParticlePDG * p = PDGLibrary::Instance()->Find(pdgc);
+    if(!p) continue;
+    bool inhibit = GetConfig().GetBool(key);
+    if ( dc >= p->NDecayChannels() ) {
+      LOG("Decay", pWARN)
+        << "Attempted to " << (inhibit?"":"un") << "inhibit decay channel "
+        << dc << " of " << p->GetName() << "(" << pdgc << ") which doesn't exist";
+      continue;
+    }
+    if(inhibit) {
       LOG("Decay", pINFO)
-         << "Configured to inhibit " <<  p->GetName()
-         << "'s decay channel " << dc;
+        << "Configured to inhibit " <<  p->GetName()
+        << "'s decay channel " << dc;
       this->InhibitDecay(pdgc, p->DecayChannel(dc));
-    }//val[key]=true?
+    } else {
+      LOG("Decay", pINFO)
+        << "Configured to uninhibit " <<  p->GetName()
+        << "'s decay channel " << dc;
+      this->UnInhibitDecay(pdgc, p->DecayChannel(dc));
+    }
   }//key iterator
 
 
@@ -223,5 +236,36 @@ void Decayer::LoadConfig(void)
        << "\nConfigured to inhibit decays of: " << fParticlesNotToDecay
        << "\n";
   }
+
+  // Print out decay info about a particles decay channels if requested
+  //
+  klist = GetConfig().FindKeys("PrintParticleDecayChannels=");
+  kiter = klist.begin();
+  for( ; kiter != klist.end(); ++kiter) {
+    RgKey key = *kiter;
+    bool doprint = GetConfig().GetBool(key);
+    vector<string> kv = utils::str::Split(key,"=");
+    assert(kv.size()==2);
+    int pdgc = atoi(kv[1].c_str());
+    TParticlePDG * p = PDGLibrary::Instance()->Find(pdgc);
+    if ( ! p ) {
+      LOG("Decay",pFATAL)
+        << "PrintParticleDecayChannels: no PDGLibrary entry for pdgc=" << pdgc
+        << " (" << kv[1].c_str() << "), check CommonDecay.xml";
+      continue;
+    }
+    LOG("Decay",pINFO) << "PrintDecayInfo for pdgc=" << pdgc
+                       << " (" << kv[1].c_str()
+                       << ") " << (doprint?"yes":"no");
+    if (doprint) { this->PrintDecayChannelInfo(pdgc); }
+  }
+
+}
+//___________________________________________________________________________
+void Decayer::PrintDecayChannelInfo(int pdgc) const
+{
+  LOG("Decay",pWARN)
+    << "No implementation for PrintDecayInfo(" << pdgc << ") for "
+    << typeid(*this).name(); 
 }
 //___________________________________________________________________________

--- a/src/Physics/Decay/Decayer.h
+++ b/src/Physics/Decay/Decayer.h
@@ -53,6 +53,8 @@ protected:
   virtual void InhibitDecay  (int pdgc, TDecayChannel * dc=0) const = 0;
   virtual void UnInhibitDecay(int pdgc, TDecayChannel * dc=0) const = 0;
 
+  virtual void PrintDecayChannelInfo (int pdgc) const;
+
   bool        fGenerateWeighted;    ///< generate weighted or unweighted decays?
   bool        fRunBefHadroTransp;   ///< is invoked before or after FSI?
   PDGCodeList fParticlesToDecay;    ///< list of particles to be decayed

--- a/src/Physics/Decay/Pythia8Decayer2023.cxx
+++ b/src/Physics/Decay/Pythia8Decayer2023.cxx
@@ -1,6 +1,6 @@
 //____________________________________________________________________________
 /*
- Copyright (c) 2003-2025, The GENIE Collaboration
+ Copyright (c) 2003-2026, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
 
  Costas Andreopoulos <constantinos.andreopoulos \at cern.ch>
@@ -10,6 +10,11 @@
 
 #include <vector>
 #include <cassert>
+#include <algorithm>
+
+#include <iostream>
+#include <sstream>
+#include <iomanip>
 
 #include <TClonesArray.h>
 #include <TLorentzVector.h>
@@ -298,13 +303,17 @@ void Pythia8Decayer2023::InhibitDecay(int pdg_code, TDecayChannel * dc) const
 {
   if(! this->IsHandled(pdg_code)) return;
 
+  LOG("Pythia8Decay",pINFO)
+    << "InhibitDecay for pdgc " << pdg_code << " PDGLibrary channel "
+    << (dc?dc->Number():-999) << " [ -999 = all ]";
+
 #ifdef __GENIE_PYTHIA8_ENABLED__
 
   Pythia8::Pythia* gPythia = Pythia8Singleton::Instance()->Pythia8();
   bool known = gPythia->particleData.isParticle(pdg_code);
   if ( ! known ) {
     LOG("Pythia8Decay", pERROR)
-      << "Can not switch off decays of " << pdg_code
+      << "Can not switch off decays of pdgc " << pdg_code
       << " as it is UNKNOWN to Pythia8";
     return;
   }
@@ -315,27 +324,39 @@ void Pythia8Decayer2023::InhibitDecay(int pdg_code, TDecayChannel * dc) const
   int ilast_chan  = pdentry->sizeChannels() - 1;
   if (ilast_chan < 0) {
     LOG("Pythia8Decay", pDEBUG)
-      << "No available decay channels for " << pdg_code;
+      << "No available decay channels for pdgc " << pdg_code;
     return;
   }
 
-  if(dc) {
-    LOG("Pythia8Decay", pFATAL)
-       << "Switching off individual decay channels for particle = " << pdg_code
-       << " is NOT yet supported for Pythia8";
-    exit(42);
-    return;
+  if (dc) {
+    // find the matching channel set ifirst_chan,ilast_chan to that
+    LOG("Pythia8Decay",pDEBUG)
+      << "Need to map TDatabasePDG channel to Pythia8 channel for " << pdg_code;
+    int ichannel = FindPythiaDecayChannel(pdg_code,dc);
+    if (ichannel < 0) {
+      LOG("Pythia8Decay",pWARN)
+        << "Could not map TDecayChannel " << dc->Number() << " to a Pythia8 channel";
+      return;
+    }
+    LOG("Pythia8Decay",pINFO)
+      << "TDatabasePDG channel " << dc->Number() << " mapped to Pythia8 " << ichannel;
+    // toggle just the one channel
+    ifirst_chan = ichannel;
+    ilast_chan  = ichannel;
   }
 
+  LOG("Pythia8Decay",pINFO)
+    << "Inhibiting Pythia8 channels [" << ifirst_chan << "," << ilast_chan << "] of pdgc " << pdg_code;
   //std::cout << "Before inhibiting channels " << ifirst_chan << "," << ilast_chan
   //          << " of " << pdg_code << std::endl;
   //gPythia->particleData.list(pdg_code);
 
   for (int ichan=ifirst_chan; ichan<=ilast_chan; ++ichan) {
     int onMode = pdentry->channel(ichan).onMode();
-    // 4 possible modes:  0=off particle & antiparticle; 1=on both; 2=on particle only; 3=on antiparticle only
+    int onMode_original = onMode;
     bool is_particle = (pdg_code>0);
-    // we're trying to turn off the mode
+    // 4 possible modes:  0=off particle & antiparticle; 1=on both; 2=on particle only; 3=on antiparticle only
+    // we're trying to turn _off_ the mode
     switch ( onMode ) {
     case 0: // off for particles & antiparticles
       break; // already off
@@ -349,10 +370,11 @@ void Pythia8Decayer2023::InhibitDecay(int pdg_code, TDecayChannel * dc) const
       onMode = (is_particle ? 3 : 0);
       break;
     }
+    LOG("Pythia8Decay", pINFO) << " change py8 ichan " << ichan << ": " << onMode_original << " to " << onMode;
     pdentry->channel(ichan).onMode(onMode);
   }
 
-  //std::cout << "After inhibiting channels " << ifirst_chan << "," << ilast_chan
+  //std::cout << "*** After inhibiting channels " << ifirst_chan << "," << ilast_chan
   //          << " of " << pdg_code << std::endl;
   //gPythia->particleData.list(pdg_code);
 
@@ -370,13 +392,17 @@ void Pythia8Decayer2023::UnInhibitDecay(int pdg_code, TDecayChannel * dc) const
 {
   if(! this->IsHandled(pdg_code)) return;
 
+  LOG("Pythia8Decay",pINFO)
+    << "UnInhibitDecay for pdgc " << pdg_code << " PDGLibrary channel "
+    << (dc?dc->Number():-999) << " [ -999 = all ]";
+
 #ifdef __GENIE_PYTHIA8_ENABLED__
 
   Pythia8::Pythia* gPythia = Pythia8Singleton::Instance()->Pythia8();
   bool known = gPythia->particleData.isParticle(pdg_code);
   if ( ! known ) {
     LOG("Pythia8Decay", pERROR)
-      << "Can not switch on decays of " << pdg_code
+      << "Can not switch on decays of pdgc " << pdg_code
       << " as it is UNKNOWN to Pythia8";
     return;
   }
@@ -387,27 +413,39 @@ void Pythia8Decayer2023::UnInhibitDecay(int pdg_code, TDecayChannel * dc) const
   int ilast_chan  = pdentry->sizeChannels() - 1;
   if (ilast_chan < 0) {
     LOG("Pythia8Decay", pDEBUG)
-      << "No available decay channels for " << pdg_code;
+      << "No available decay channels for pdgc " << pdg_code;
     return;
   }
 
-  if(dc) {
-    LOG("Pythia8Decay", pFATAL)
-       << "Switching on individual decay channels for particle = " << pdg_code
-       << " is NOT yet supported for Pythia8";
-    exit(42);
-    return;
+  if (dc) {
+    // find the matching channel set ifirst_chan,ilast_chan to that
+    LOG("Pythia8Decay",pDEBUG)
+      << "Need to map TDatabasePDG channel to Pythia8 channel for " << pdg_code << " (" << dc->Number() << ")";
+    int ichannel = FindPythiaDecayChannel(pdg_code,dc);
+    if (ichannel < 0) {
+      LOG("Pythia8Decay",pWARN)
+        << "Could not map TDecayChannel " << dc->Number() << " to a Pythia8 channel";
+      return;
+    }
+    LOG("Pythia8Decay",pINFO)
+      << "TDatabasePDG channel " << dc->Number() << " mapped to Pythia8 " << ichannel;
+    // toggle just the one channel
+    ifirst_chan = ichannel;
+    ilast_chan  = ichannel;
   }
 
+  LOG("Pythia8Decay",pINFO)
+    << "Unihibiting Pythia8 channels [" << ifirst_chan << "," << ilast_chan << "] of pdgc " << pdg_code;
   //std::cout << "Before uninhibiting channels " << ifirst_chan << "," << ilast_chan
   //          << " of " << pdg_code << std::endl;
   //gPythia->particleData.list(pdg_code);
 
   for (int ichan=ifirst_chan; ichan<=ilast_chan; ++ichan) {
     int onMode = pdentry->channel(ichan).onMode();
-    // 4 possible modes:  0=off particle & antiparticle; 1=on both; 2=on particle only; 3=on antiparticle only
+    int onMode_original = onMode;
     bool is_particle = (pdg_code>0);
-    // we're trying to turn off the mode
+    // 4 possible modes:  0=off particle & antiparticle; 1=on both; 2=on particle only; 3=on antiparticle only
+    // we're trying to turn _on_ the mode
     switch ( onMode ) {
     case 0: // off for particles & antiparticles
       onMode = (is_particle ? 2 : 3);
@@ -415,12 +453,13 @@ void Pythia8Decayer2023::UnInhibitDecay(int pdg_code, TDecayChannel * dc) const
     case 1: // on for both particle & antiparticle
       break; // already on
     case 2: // on for particle only
-      onMode = (is_particle ? 2 : 0);
+      onMode = (is_particle ? 2 : 1);
       break;
     case 3: // on for antiparticle only
-      onMode = (is_particle ? 0 : 3);
+      onMode = (is_particle ? 1 : 3);
       break;
     }
+    LOG("Pythia8Decay", pINFO) << " change py8 ichan " << ichan << ": " << onMode_original << " to " << onMode;
     pdentry->channel(ichan).onMode(onMode);
   }
 
@@ -462,16 +501,69 @@ double Pythia8Decayer2023::SumOfBranchingRatios(int /* kc */ ) const
   return sumbr;
 }
 //____________________________________________________________________________
-int Pythia8Decayer2023::FindPythiaDecayChannel(int /* kc */, TDecayChannel* dc) const
+int Pythia8Decayer2023::FindPythiaDecayChannel(int pdgc, TDecayChannel* dc) const
 {
-  if(!dc) return -1;
 
 #ifdef __GENIE_PYTHIA8_ENABLED__
+  LOG("Pythia8Decay",pDEBUG)
+    << "looking for " << pdgc << " channel " << dc->Number();
 
-  LOG("Pythia8Decay", pFATAL)
-    << "Pythia8Decayer2023::FindPythiaDecayChannel() not yet implemented";
-  gAbortingInErr = true;
-  std::exit(1);
+  // Get the one-and-only instance of Pythia8 that GENIE will use
+  Pythia8::Pythia* gPythia = genie::Pythia8Singleton::Instance()->Pythia8();
+  if ( ! gPythia->particleData.isParticle(pdgc) ) {
+    LOG("Pythia8Decay",pWARN) << "Pythia8 doesn't know about pdg " << pdgc;
+    return -1;
+  }
+
+  // gather info from TDatabasePDG channel; get sorted list of daughters to match
+  int nd = dc->NDaughters();
+  vector<int> dc_daughter(nd);
+  for (int i=0; i < nd; ++i) dc_daughter[i] = dc->DaughterPdgCode(i);
+  sort( dc_daughter.begin(), dc_daughter.end() );
+
+  auto pdentry = gPythia->particleData.particleDataEntryPtr(pdgc);
+  // loop over Pythia8 channels looking for a match
+  int nChan = pdentry->sizeChannels();
+
+  LOG("Pythia8Decay",pDEBUG) << " dc has nd " << nd << " daughters "
+                             << " pythia8 has nChan " << nChan;
+
+  for (int iChan=0; iChan < nChan; ++iChan) {
+    auto p8dkchan = pdentry->channel(iChan);
+
+    int nmult = p8dkchan.multiplicity();
+    // must have same number of daughters
+    if (nd != nmult) {
+      LOG("Pythia8Decay",pDEBUG) << "iChan " << iChan << " " << nd << " != " << nmult;
+      continue;
+    }
+
+    vector<int> py_daughter(nmult);
+    for (int j=0; j < nmult; ++j) {
+      // pythia8 decay list is for particles, not antiparticles
+      // if we're getting the daughters of an antiparticle, then reverse them
+      int py_dau = p8dkchan.product(j);
+      if (pdgc<0) py_dau = gPythia->particleData.antiId(py_dau);
+      py_daughter[j] = py_dau;
+    }
+    sort ( py_daughter.begin(), py_daughter.end() );
+
+    // now compare the lists
+    bool match = true;
+    for (int k=0; k < nd; ++k) {
+      LOG("Pythia8Decay",pDEBUG) << "   iChan " << iChan << " k=" << k
+                                 << " " << dc_daughter[k] << " vs. " << py_daughter[k];
+      if (dc_daughter[k] != py_daughter[k]) {
+        match = false;  // mismatch
+        break; // we're done with this iChan
+      }
+    }
+    // made it through the vector comparison; have a match?
+    if (match) {
+      LOG("Pythia8Decay",pDEBUG) << "iChan " << iChan << " match " << (match?"yes":"no");
+      return iChan;
+    }
+  } // loop over iChan
 
 #else
   LOG("Pythia8Decay", pFATAL)
@@ -482,26 +574,73 @@ int Pythia8Decayer2023::FindPythiaDecayChannel(int /* kc */, TDecayChannel* dc) 
 
   return -1;
 }
-//____________________________________________________________________________
-bool Pythia8Decayer2023::MatchDecayChannels(int /* ichannel */, TDecayChannel* /* dc */) const
+//___________________________________________________________________________
+void Pythia8Decayer2023::PrintDecayChannelInfo(int pdgc) const
 {
-  // num. of daughters in the input TDecayChannel & the input PYTHIA ichannel
-  //int nd = dc->NDaughters();
+  LOG("Decay",pDEBUG)
+    << "Real implementation for PrintDecayInfo(" << pdgc << ") for "
+    << typeid(*this).name();
 
-#ifdef __GENIE_PYTHIA8_ENABLED__
+  TParticlePDG * p = PDGLibrary::Instance()->Find(pdgc);
+  if ( ! p ) {
+    LOG("Pythia8Decay",pWARN) << "PDGLibrary doesn't know about pdg " << pdgc;
+    return;
+  }
 
-  LOG("Pythia8Decay", pFATAL)
-    << "Pythia8Decayer2023::MatchDecayChannels() not yet implemented";
-  gAbortingInErr = true;
-  std::exit(1);
+  // Get the one-and-only instance of Pythia8 that GENIE will use
+  Pythia8::Pythia* gPythia = genie::Pythia8Singleton::Instance()->Pythia8();
+  if ( ! gPythia->particleData.isParticle(pdgc) ) {
+    LOG("Pythia8Decay",pWARN) << "Pythia8 doesn't know about pdg " << pdgc;
+    return;
+  }
 
-#else
-  LOG("Pythia8Decay", pFATAL)
-    << "calling GENIE/PYTHIA8 decay without enabling PYTHIA8";
-  gAbortingInErr = true;
-  std::exit(1);
-#endif
+  auto py8_p  = gPythia->particleData.particleDataEntryPtr(pdgc);
 
-  return true;
+  std::ostringstream ss;
+  ss << "\n";
+  double brsum=0.0, brsum_py8=0.0;
+  for (int ic=0; ic < p->NDecayChannels(); ++ic) {
+    TDecayChannel * dch = p->DecayChannel(ic);
+    double br     = dch->BranchingRatio();
+    double br_py8     =  0;
+    int    onMode_py8 = -1;
+    // does this PDGLibrary channel map to something in Pythia8?
+    int ic_py8 = FindPythiaDecayChannel(pdgc,dch); // -1 if no match
+    if (ic_py8>=0) {
+      auto py8_dk = py8_p->channel(ic_py8);
+      br_py8      = py8_dk.bRatio();
+      onMode_py8  = py8_dk.onMode();
+    }
+    brsum     += br;
+    brsum_py8 += br_py8;
+    ss << "    " << std::setw(2) << ic
+       << " " << std::fixed << std::setprecision(8) << br << " [ ";
+    if (ic_py8<0) {
+      ss << "-- - ----------";
+    } else {
+      ss << std::setw(2) << ic_py8 << " "
+         << std::setw(1) << onMode_py8 << " "
+         << std::setprecision(8) << br_py8;
+    }
+    ss << " ] ==> ";
+    for (int kdau=0; kdau < dch->NDaughters(); ++kdau) {
+      int pdgc_dau = dch->DaughterPdgCode(kdau);
+      TParticlePDG * p_dau = PDGLibrary::Instance()->Find(pdgc_dau);
+      ss << p_dau->GetName() << "(" << pdgc_dau << ")";
+      if ( kdau < dch->NDaughters() -1 ) ss << " + ";
+    }
+    ss << "\n";
+  }
+  ss << " BRsum " << std::setprecision(8) << brsum
+     << " BRsum_py8 " << std::setprecision(8) << brsum_py8;
+  LOG("Pythia8Decay",pNOTICE)
+    << "\n PDGLibrary decay channels for " <<  p->GetName() << "(" << pdgc << ")"
+    << "\n iChan BRatio [ pythia8chan onMode BRatio ] "
+    << ss.str() << "\n";
+
+  LOG("Pythia8Decay",pNOTICE)
+    << " Pythia8 view of decays for " <<  py8_p->name() << "(" << pdgc << ")";
+  gPythia->particleData.list(pdgc);
+
 }
-//____________________________________________________________________________
+//___________________________________________________________________________

--- a/src/Physics/Decay/Pythia8Decayer2023.cxx
+++ b/src/Physics/Decay/Pythia8Decayer2023.cxx
@@ -599,6 +599,7 @@ void Pythia8Decayer2023::PrintDecayChannelInfo(int pdgc) const
   std::ostringstream ss;
   ss << "\n";
   double brsum=0.0, brsum_py8=0.0;
+  std::set<int> py8matches;
   for (int ic=0; ic < p->NDecayChannels(); ++ic) {
     TDecayChannel * dch = p->DecayChannel(ic);
     double br     = dch->BranchingRatio();
@@ -618,6 +619,7 @@ void Pythia8Decayer2023::PrintDecayChannelInfo(int pdgc) const
     if (ic_py8<0) {
       ss << "-- - ----------";
     } else {
+      py8matches.insert(ic_py8);
       ss << std::setw(2) << ic_py8 << " "
          << std::setw(1) << onMode_py8 << " "
          << std::setprecision(8) << br_py8;
@@ -632,7 +634,18 @@ void Pythia8Decayer2023::PrintDecayChannelInfo(int pdgc) const
     ss << "\n";
   }
   ss << " BRsum " << std::setprecision(8) << brsum
-     << " BRsum_py8 " << std::setprecision(8) << brsum_py8;
+     << " BRsum_py8 " << std::setprecision(8) << brsum_py8 << "\n";
+  ss <<    "The following pythia channels are not accessible from InhibitDecay/Particle:" << "\n";
+  //std::set<int> py8missing;
+  int npy8chan = py8_p->sizeChannels();
+  for (int ic_py8=0; ic_py8 < npy8chan; ++ic_py8) {
+    //c++20 if ( ! py8matches.contains(ic_py8) ) {
+    if ( py8matches.find(ic_py8) == py8matches.end() ) {
+      //py8missing.insert(ic_py8);
+      ss << " " << ic_py8;
+    }
+  }
+
   LOG("Pythia8Decay",pNOTICE)
     << "\n PDGLibrary decay channels for " <<  p->GetName() << "(" << pdgc << ")"
     << "\n iChan BRatio [ pythia8chan onMode BRatio ] "

--- a/src/Physics/Decay/Pythia8Decayer2023.h
+++ b/src/Physics/Decay/Pythia8Decayer2023.h
@@ -39,6 +39,9 @@ public:
   // Implement the EventRecordVisitorI interface
   void ProcessEventRecord(GHepRecord * event) const;
 
+  void   PrintDecayChannelInfo  (int pdgc)                       const;
+  int    FindPythiaDecayChannel (int kc, TDecayChannel * ch)     const;
+
 private:
 
   void   Initialize             (void)                           const;
@@ -47,8 +50,6 @@ private:
   void   UnInhibitDecay         (int pdgc, TDecayChannel * ch=0) const;
   bool   Decay                  (int ip, GHepRecord * event)     const;
   double SumOfBranchingRatios   (int kc)                         const;
-  int    FindPythiaDecayChannel (int kc, TDecayChannel * ch)     const;
-  bool   MatchDecayChannels     (int ic, TDecayChannel * ch)     const;
 
   mutable double     fWeight;
 };


### PR DESCRIPTION
Implement method for matching PDGLibrary/TDatabasePDG channels to Pythia8 channels via FindPythiaDecayChannel(); give warnings if a match isn't found
Correct state flipping of onMode for turning "on" channels
Implement new virtual PrintDecayChannelInfo() method specific to Pythia8 case
Add to more comments to config/CommonDecay.xml regarding these changes