### PR TITLE
fix for detecting both Geant4 v10 and v11

### DIFF
--- a/configure
+++ b/configure
@@ -885,16 +885,19 @@ if($gopt_enable_geant4_interface eq "YES") {
   # if it still not set, try autodetecting it
   if(! -d $gopt_with_geant4_lib && $auto_detect)  {
     print "Auto-detecting GEANT4 library path...\n";
-    $matched = auto_detect("libG4processes.so");
-    if( $matched=~m/(\S*)\/libG4processes.so/i ) {
+    # v10 has libG4processes.so, but v11 has libG4processes_core.so 
+    $matched = auto_detect("libG4processes.so","libG4processes_core.so");
+    if( $matched=~m/(\S*)\/(?:libG4processes|libG4processes_core)\.so/i ) {
        $gopt_with_geant4_lib = $1;
     }
     print "Setting --with-geant4-lib=$gopt_with_geant4_lib\n";
   }
   # check
-  my $fileso    = "$gopt_with_geant4_lib/libG4processes.so";
-  my $filedylib = "$gopt_with_geant4_lib/libG4processes.dylib";
-  if(! -e $fileso && ! -e $filedylib) {
+  my $file10so    = "$gopt_with_geant4_lib/libG4processes.so";
+  my $file10dylib = "$gopt_with_geant4_lib/libG4processes.dylib";
+  my $file11so    = "$gopt_with_geant4_lib/libG4processes_core.so";
+  my $file11dylib = "$gopt_with_geant4_lib/libG4processes_core.dylib";
+  if(! -e $file10so && ! -e $file10dylib && ! -e $file11so && ! -e $file11dylib) {
      print "*** Error *** You need to specify the path to GEANT4 library using --with-geant4-lib=/some/path/\n";
      print "*** Error *** Otherwise, you should --disable-geant4\n\n";
      exit 1;


### PR DESCRIPTION
Geant4 v11 splits the `libG4processes.so` library into `libG4processes_core.so` and `libG4process_hadronic.so` .  In `configure` it tests to make sure the library exists to ensure that you specified the path correctly.  Make it test for either.   Linking to an appropriate library list happens through the use of `geant4-config` which is found relative to this path.