### PR TITLE
Rework RNG initialisation to only fire once so Pythia8 does not silently fail

### DIFF
--- a/src/Apps/gAtmoEvGen.cxx
+++ b/src/Apps/gAtmoEvGen.cxx
@@ -332,6 +332,9 @@ int main(int argc, char** argv)
   // Parse command line arguments
   GetCommandLineArgs(argc,argv);
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -341,7 +344,6 @@ int main(int argc, char** argv)
   // Iinitialization of random number generators, cross-section table, messenger, cache etc...
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
   utils::app_init::CacheFile(RunOpt::Instance()->CacheFile());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, true);
 
   // get geometry driver

--- a/src/Apps/gEvGen.cxx
+++ b/src/Apps/gEvGen.cxx
@@ -273,6 +273,9 @@ int main(int argc, char ** argv)
 void Initialize()
 {
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gevgen", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -283,7 +286,6 @@ void Initialize()
   // messenger thresholds, cache file
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
   utils::app_init::CacheFile(RunOpt::Instance()->CacheFile());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, false);
 
   // Set GHEP print level

--- a/src/Apps/gEvGenDM.cxx
+++ b/src/Apps/gEvGenDM.cxx
@@ -271,6 +271,9 @@ int main(int argc, char ** argv)
 void Initialize()
 {
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -281,7 +284,6 @@ void Initialize()
   // messenger thresholds, cache file
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
   utils::app_init::CacheFile(RunOpt::Instance()->CacheFile());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, false);
 
   // Set GHEP print level

--- a/src/Apps/gEvGenHadronNucleus.cxx
+++ b/src/Apps/gEvGenHadronNucleus.cxx
@@ -161,6 +161,9 @@ int main(int argc, char ** argv)
   // Parse command line arguments
   GetCommandLineArgs(argc,argv);
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -170,7 +173,6 @@ int main(int argc, char ** argv)
   // Init random number generator generator with user-specified seed number,
   // set user-specified mesg thresholds, set user-specified GHEP print-level
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
-  utils::app_init::RandGen(gOptRanSeed);
   GHepRecord::SetPrintLevel(RunOpt::Instance()->EventRecordPrintLevel());
 
   // Build the incident hadron kinetic energy spectrum, if required

--- a/src/Apps/gEvGenLArDM.cxx
+++ b/src/Apps/gEvGenLArDM.cxx
@@ -392,6 +392,9 @@ int main(int argc, char ** argv)
       r->Lock();
   }
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -402,7 +405,6 @@ int main(int argc, char ** argv)
   // messenger thresholds, cache file
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
   utils::app_init::CacheFile(RunOpt::Instance()->CacheFile());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, false);
 
   // Set GHEP print level

--- a/src/Apps/gFNALExptEvGen.cxx
+++ b/src/Apps/gFNALExptEvGen.cxx
@@ -428,6 +428,9 @@ int main(int argc, char ** argv)
   LoadExtraOptions();
   GetCommandLineArgs(argc,argv);
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -438,7 +441,6 @@ int main(int argc, char ** argv)
   // messenger thresholds, cache file
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
   utils::app_init::CacheFile(RunOpt::Instance()->CacheFile());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, false);
 
   // Set GHEP print level

--- a/src/Apps/gMakeSplines.cxx
+++ b/src/Apps/gMakeSplines.cxx
@@ -147,6 +147,9 @@ int main(int argc, char ** argv)
   // Parse command line arguments
   GetCommandLineArgs(argc,argv);
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -160,7 +163,6 @@ int main(int argc, char ** argv)
 
   // Init
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, false);
 
   // Get list of neutrinos and nuclear targets

--- a/src/Apps/gMakeSplinesDM.cxx
+++ b/src/Apps/gMakeSplinesDM.cxx
@@ -155,6 +155,9 @@ int main(int argc, char ** argv)
   // Parse command line arguments
   GetCommandLineArgs(argc,argv);
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -182,7 +185,6 @@ int main(int argc, char ** argv)
 
         // Init
         utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
-        utils::app_init::RandGen(gOptRanSeed);
         utils::app_init::XSecTable(gOptInpXSecFile, false);
 
         // Get list of neutrinos and nuclear targets

--- a/src/Apps/gT2KEvGen.cxx
+++ b/src/Apps/gT2KEvGen.cxx
@@ -526,6 +526,8 @@ int main(int argc, char ** argv)
   // Parse command line arguments
   GetCommandLineArgs(argc,argv);
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
 
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
@@ -537,7 +539,6 @@ int main(int argc, char ** argv)
   // messenger thresholds, cache file
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
   utils::app_init::CacheFile(RunOpt::Instance()->CacheFile());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, true);
 
   // Set GHEP print level

--- a/src/Apps/gUpMuFluxGen.cxx
+++ b/src/Apps/gUpMuFluxGen.cxx
@@ -174,6 +174,9 @@ int main(int argc, char** argv)
   // Parse command line arguments
   GetCommandLineArgs(argc,argv);
 
+  // Seed should always be initialised first.
+  utils::app_init::RandGen(gOptRanSeed);
+
   if ( ! RunOpt::Instance()->Tune() ) {
     LOG("gmkspl", pFATAL) << " No TuneId in RunOption";
     exit(-1);
@@ -182,7 +185,6 @@ int main(int argc, char** argv)
 
   // Init
   utils::app_init::MesgThresholds(RunOpt::Instance()->MesgThresholdFiles());
-  utils::app_init::RandGen(gOptRanSeed);
   utils::app_init::XSecTable(gOptInpXSecFile, true);
 
 

--- a/src/Framework/Numerical/RandomGen.cxx
+++ b/src/Framework/Numerical/RandomGen.cxx
@@ -26,25 +26,14 @@ namespace genie {
 
 //____________________________________________________________________________
 RandomGen * RandomGen::fInstance = 0;
+bool RandomGen::fInitialized = false;
 //____________________________________________________________________________
-RandomGen::RandomGen()
+RandomGen::RandomGen() : fCurrSeed(kDefaultRandSeed)
 {
   LOG("Rndm", pINFO) << "RandomGen late initialization";
 
-  fInitalized = false;
+  fInitialized = false;
   fInstance = 0;
-/*
-  // try to get this job's random number seed from the environment
-  const char * seed = gSystem->Getenv("GSEED");
-  if(seed) {
-    LOG("Rndm", pDEBUG) << "Reading RandomNumGenerator seed env. var $GSEED";
-    fCurrSeed = atoi(seed);
-  } else {
-    LOG("Rndm", pINFO) << "Env. var. $GSEED is not set. Using default seed";
-    fCurrSeed = kDefaultRandSeed; // default seed number
-  }
-  this->InitRandomGenerators(fCurrSeed);
-*/
 
   if ( gSystem->Getenv("GSEED") ) {
     LOG("Rndm", pFATAL)
@@ -59,10 +48,40 @@ RandomGen::RandomGen()
     exit(1);
   }
 
-  fCurrSeed = kDefaultRandSeed; // a default seed number is set a init
   this->InitRandomGenerators(fCurrSeed);
 
-  fInitalized = true;
+  fInitialized = true;
+}
+//____________________________________________________________________________
+RandomGen::RandomGen(long int seed) : fCurrSeed(seed)
+{
+  LOG("Rndm", pINFO) << "RandomGen late initialization";
+
+  fInitialized = false;
+  fInstance = 0;
+
+  if ( gSystem->Getenv("GSEED") ) {
+    LOG("Rndm", pFATAL)
+      << "\n\n"
+      << "************************************************************************************** \n"
+      << "The random number seed is no longer set via the $GSEED variable.\n"
+      << "Please use the --seed option implemented in all GENIE apps or, if you access RandomGen \n"
+      << "directly in your user code, use RandomGen::SetSeed(long int seed).\n"
+      << "Unset $GSEED to continue running GENIE. \n"
+      << "************************************************************************************** \n";
+    gAbortingInErr = true;
+    exit(1);
+  }
+
+  this->InitRandomGenerators(fCurrSeed);
+
+  fInitialized = true;
+}
+//____________________________________________________________________________
+void RandomGen::InitRandomGenerators(long int seed)
+{
+  fRandom3 = new TRandom3();
+  this->SetSeed(seed);
 }
 //____________________________________________________________________________
 RandomGen::~RandomGen()
@@ -77,19 +96,33 @@ RandomGen * RandomGen::Instance()
     static RandomGen::Cleaner cleaner;
     cleaner.DummyMethodAndSilentCompiler();
 
-    fInstance = new RandomGen;
+    fInstance = new RandomGen();
   }
   return fInstance;
+
+}
+//____________________________________________________________________________
+RandomGen * RandomGen::Instance(long int seed)
+{
+  if(fInstance == 0) {
+    static RandomGen::Cleaner cleaner;
+    cleaner.DummyMethodAndSilentCompiler();
+
+    fInstance = new RandomGen(seed);
+  }
+  return fInstance;
+
+}
+//____________________________________________________________________________
+bool RandomGen::IsInitialized()
+{
+  return fInitialized;
 }
 //____________________________________________________________________________
 void RandomGen::SetSeed(long int seed)
 {
   LOG("Rndm", pNOTICE)
-     << "Setting"
-     << ((fInitalized) ? " " : " default ")
-     << "random number seed"
-     << ((fInitalized) ? ": " : " at random number generator initialization: ")
-     << seed;
+     << "Setting random number seed: " << seed;
 
   // Set the seed number for all internal GENIE random number generators
   this->RndKine ().SetSeed(seed);
@@ -128,12 +161,6 @@ void RandomGen::SetSeed(long int seed)
 #ifdef __GENIE_PYTHIA6_ENABLED__
   LOG("Rndm", pINFO) << "PYTHIA6  seed = " << pythia6->GetMRPY(1);
 #endif
-}
-//____________________________________________________________________________
-void RandomGen::InitRandomGenerators(long int seed)
-{
-  fRandom3 = new TRandom3();
-  this->SetSeed(seed);
 }
 //____________________________________________________________________________
 } // genie namespace

--- a/src/Framework/Numerical/RandomGen.h
+++ b/src/Framework/Numerical/RandomGen.h
@@ -32,6 +32,10 @@ public:
 
   //! Access instance
   static RandomGen * Instance();
+  static RandomGen * Instance(long int seed);
+
+  //! Check if initialized
+  static bool IsInitialized();
 
   //! Random number generators used by various GENIE modules.
   //! (See note at http://root.cern.ch/root/html//TRandom.html
@@ -85,14 +89,15 @@ public:
 private:
 
   RandomGen();
+  RandomGen(long int seed);
   RandomGen(const RandomGen & rgen);
   virtual ~RandomGen();
 
   static RandomGen * fInstance;
 
-  TRandom3 * fRandom3;    ///< Mersenne Twistor
-  long int   fCurrSeed;   ///< random number generator seed number
-  bool       fInitalized; ///< done initializing singleton?
+  TRandom3 *  fRandom3;     ///< Mersenne Twistor
+  long int    fCurrSeed;    ///< random number generator seed number
+  static bool fInitialized; ///< done initializing singleton?
 
   void InitRandomGenerators(long int seed);
 

--- a/src/Framework/Utils/AppInit.cxx
+++ b/src/Framework/Utils/AppInit.cxx
@@ -30,9 +30,15 @@ using namespace genie;
 void genie::utils::app_init::RandGen(long int seed)
 {
   // Set random number seed, if a value was set at the command-line.
-  if(seed > 0) {
-    RandomGen::Instance()->SetSeed(seed);
-  }
+  if( ! RandomGen::IsInitialized() ) {
+    if(seed > 0) { 
+      RandomGen::Instance(seed);
+    } else RandomGen::Instance();
+  } else {
+    if(seed > 0) {
+      RandomGen::Instance()->SetSeed(seed);
+    }
+  } // if first initialisation
 }
 //___________________________________________________________________________
 void genie::utils::app_init::XSecTable (string inpfile, bool require_table)

--- a/src/Physics/Decay/Pythia8Decayer2023.cxx
+++ b/src/Physics/Decay/Pythia8Decayer2023.cxx
@@ -267,10 +267,16 @@ void Pythia8Decayer2023::Initialize(void) const
   long int seed = rnd->GetSeed();
   gPythia->readString("Random::setSeed = on");
   gPythia->settings.mode("Random:seed",seed);
+
+  LOG("Pythia8Decay", pFATAL)
+    << "Setting PYTHIA8 seed -> " << seed;
+
+
+  // Pythia8 only allows one initialisation unless you specifically ask for re-init with a file.
+  if( ! gPythia->settings.getIsInit() ) { gPythia->init(); }
+
   LOG("Pythia8Decay", pINFO)
     << "PYTHIA8 seed = " << gPythia->settings.mode("Random:seed");
-
-  gPythia->init();
 
   // shut off decays of pi0's as we want Geant4 to handle them
   // if other immediate decay products should be handled by Geant4,


### PR DESCRIPTION
SBND users doing an eta analysis using GENIE v3.06.02 reported that the angle between the two photons of η->γγ looked strange. (see Gen 2 orange curve, vs Gen 1 using GENIE v3.04.02 and Pythia 6)
<img width="415" height="325" alt="image" src="https://github.com/user-attachments/assets/0ad4c0d6-61f7-406d-93c1-ef2173d1f239" />

Suspicion was pointed at the random number seed setting for Pythia8. I confirmed that, despite the `SetSeed()` method in `RandomGen` firing, the Pythia8 seed does not get updated:
RandomGen code:
```
Pythia8::Pythia* gPythia = Pythia8Singleton::Instance()->Pythia8();
  gPythia->readString("ProcessLevel:all = off");
  gPythia->readString("ProcessLevel:resonanceDecays=on");

  gPythia->readString("Print:quiet = on");

  // sync GENIE and PYTHIA8 seeds
  RandomGen * rnd = RandomGen::Instance();
  long int seed = rnd->GetSeed();
  gPythia->readString("Random::setSeed = on");
  gPythia->settings.mode("Random:seed",seed);
  LOG("Pythia8Decay", pINFO)
    << "PYTHIA8 seed = " << gPythia->settings.mode("Random:seed");

  gPythia->init();
  ```
  Output of `gevgen` on terminal:
  ```
  SL7> bash-4.2$ SEED=137418; gevgen -p 14 --seed ${SEED} -r ${SEED} -t 1000180400 -f "x*x*exp(-x)" -e 0.1,3 --event-generator-list CCDIS --tune AR25_20i_00_000 --cross-sections /cvmfs/sbn.opensciencegrid.org/products/sbn/genie_xsec/v3_06_02_sbn2/NULL/AR2520i00000-k250-e1000/data/gxspl-NUsmall.xml --message-thresholds $(pwd)/Messenger_pythia8.xml -n 100 | egrep 'seed'
1788623417 NOTICE gevgen : [n] <gEvGen.cxx::GetCommandLineArgs (828)> : Random number seed: 137418
1788623425 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (263)> : PYTHIA8 seed = 65539
1788623425 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (263)> : PYTHIA8 seed = 65539
SL7> bash-4.2$ SEED=91241; gevgen -p 14 --seed ${SEED} -r ${SEED} -t 1000180400 -f "x*x*exp(-x)" -e 0.1,3 --event-generator-list CCDIS --tune AR25_20i_00_000 --cross-sections /cvmfs/sbn.opensciencegrid.org/products/sbn/genie_xsec/v3_06_02_sbn2/NULL/AR2520i00000-k250-e1000/data/gxspl-NUsmall.xml --message-thresholds $(pwd)/Messenger_pythia8.xml -n 100 | egrep 'seed'
1788623433 NOTICE gevgen : [n] <gEvGen.cxx::GetCommandLineArgs (828)> : Random number seed: 91241
1788623440 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (263)> : PYTHIA8 seed = 65539
1788623441 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (263)> : PYTHIA8 seed = 65539
  ```
  
  This happens because Pythia8, in `Settings.cc`, returns early and silently if it is already initialised.
  ```
  bool Settings::init(string startFile, bool append) {

  // Don't initialize if it has already been done and not in append mode.
  if (isInit && !append) return true;
  int nError = 0;
  ```
  
  GENIE used to first initialise an instance of `RandomGen`, which set the default seed, and update seeds. I have added a constructor which accepts the seed as an argument, alongside a check to see if the instance is initialised, and I've modified `utils::app_init` to check if there is an instance of `RandomGen` ; if there isn't, it intialises one with the provided seed (if no seed, the default seed is used). This satisfies Pythia8's requirement for single init.  Apps calling `utils::app_init` now call it earlier, to ensure the seed is set before tunes are constructed.
  
  Output of some calls with the fix in place:
  ```
  SL7> bash-4.2$ SEED=91241; gevgen -p 14 --seed ${SEED} -r ${SEED} -t 1000180400 -f "x*x*exp(-x)" -e 0.1,3 --event-generator-list CCDIS --tune AR25_20i_00_000 --cross-sections /cvmfs/sbn.opensciencegrid.org/products/sbn/genie_xsec/v3_06_02_sbn2/NULL/AR2520i00000-k250-e1000/data/gxspl-NUsmall.xml --message-thresholds $(pwd)/Messenger_pythia8.xml -n 100 | egrep 'seed'
1788628992 NOTICE gevgen : [n] <gEvGen.cxx::GetCommandLineArgs (830)> : Random number seed: 91241
1788628992 NOTICE Rndm : [n] <RandomGen.cxx::SetSeed (124)> : Settingrandom number seed: 91241
1788628999 FATAL Rndm : [n] <Pythia8Decayer2023.cxx::Initialize (271)> : Setting PYTHIA8 seed -> 91241
1788628999 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (278)> : PYTHIA8 seed = 91241
1788628999 FATAL Rndm : [n] <Pythia8Decayer2023.cxx::Initialize (271)> : Setting PYTHIA8 seed -> 91241
1788628999 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (278)> : PYTHIA8 seed = 91241

SL7> bash-4.2$ SEED=672393; gevgen -p 14 --seed ${SEED} -r ${SEED} -t 1000180400 -f "x*x*exp(-x)" -e 0.1,3 --event-generator-list CCDIS --tune AR25_20i_00_000 --cross-sections /cvmfs/sbn.opensciencegrid.org/products/sbn/genie_xsec/v3_06_02_sbn2/NULL/AR2520i00000-k250-e1000/data/gxspl-NUsmall.xml --message-thresholds $(pwd)/Messenger_pythia8.xml -n 100 | egrep 'seed'
1788629015 NOTICE gevgen : [n] <gEvGen.cxx::GetCommandLineArgs (830)> : Random number seed: 672393
1788629015 NOTICE Rndm : [n] <RandomGen.cxx::SetSeed (124)> : Settingrandom number seed: 672393
1788629022 FATAL Rndm : [n] <Pythia8Decayer2023.cxx::Initialize (271)> : Setting PYTHIA8 seed -> 672393
1788629022 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (278)> : PYTHIA8 seed = 672393
1788629023 FATAL Rndm : [n] <Pythia8Decayer2023.cxx::Initialize (271)> : Setting PYTHIA8 seed -> 672393
1788629023 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (278)> : PYTHIA8 seed = 672393

SL7> bash-4.2$ gevgen -p 14 -t 1000180400 -f "x*x*exp(-x)" -e 0.1,3 --event-generator-list CCDIS --tune AR25_20i_00_000 --cross-sections /cvmfs/sbn.opensciencegrid.org/products/sbn/genie_xsec/v3_06_02_sbn2/NULL/AR2520i00000-k250-e1000/data/gxspl-NUsmall.xml --message-thresholds $(pwd)/Messenger_pythia8.xml -n 100 | egrep 'seed'
1788630722 NOTICE gevgen : [n] <gEvGen.cxx::GetCommandLineArgs (833)> : Random number seed was not set, using default
1788630722 NOTICE Rndm : [n] <RandomGen.cxx::SetSeed (124)> : Setting random number seed: 65539
1788630731 FATAL Rndm : [n] <Pythia8Decayer2023.cxx::Initialize (271)> : Setting PYTHIA8 seed -> 65539
1788630731 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (278)> : PYTHIA8 seed = 65539
1788630731 FATAL Rndm : [n] <Pythia8Decayer2023.cxx::Initialize (271)> : Setting PYTHIA8 seed -> 65539
1788630731 INFO Pythia8Decay : [n] <Pythia8Decayer2023.cxx::Initialize (278)> : PYTHIA8 seed = 65539
  ```
  
  Calling @nusense for review as this touches Pythia8 and Framework, and @sjgardiner as this targets branch `rc-v380`. A separate PR to `master` is to follow.