### PR TITLE
Tweak CommonParam.xml GVLD-Emax from 1000.000 to 1000.010

### DIFF
--- a/src/Physics/HadronTransport/HAIntranuke.cxx
+++ b/src/Physics/HadronTransport/HAIntranuke.cxx
@@ -2,7 +2,6 @@
 /*
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
 
  Author: Steve Dytman <dytman+@pitt.edu>, Pittsburgh Univ.
          Aaron Meyer <asm58@pitt.edu>, Pittsburgh Univ.

--- a/src/Physics/HadronTransport/HAIntranuke2018.cxx
+++ b/src/Physics/HadronTransport/HAIntranuke2018.cxx
@@ -2,7 +2,6 @@
 /*
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
 
  Author: Steve Dytman <dytman+@pitt.edu>, Pittsburgh Univ.
          Aaron Meyer <asm58@pitt.edu>, Pittsburgh Univ.

--- a/src/Physics/HadronTransport/HAIntranuke2025.cxx
+++ b/src/Physics/HadronTransport/HAIntranuke2025.cxx
@@ -2,7 +2,6 @@
 /*
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
 
  Author: Steve Dytman <dytman+@pitt.edu>, Pittsburgh Univ.
          Aaron Meyer <asm58@pitt.edu>, Pittsburgh Univ.

--- a/src/Physics/HadronTransport/HNIntranuke2018.cxx
+++ b/src/Physics/HadronTransport/HNIntranuke2018.cxx
@@ -936,6 +936,7 @@ int HNIntranuke2018::HandleCompoundNucleus(GHepRecord* ev, GHepParticle* p, int 
                 << "*** Nothing left to interact with, escaping.";
               GHepParticle * sp = new GHepParticle(*p);
               sp->SetFirstMother(mom);
+              sp->SetLastMother(-1);
               sp->SetStatus(kIStStableFinalState);
               ev->AddParticle(*sp);
               delete sp;

--- a/src/Physics/HadronTransport/HNIntranuke2018.cxx
+++ b/src/Physics/HadronTransport/HNIntranuke2018.cxx
@@ -920,6 +920,7 @@ int HNIntranuke2018::HandleCompoundNucleus(GHepRecord* ev, GHepParticle* p, int 
             {
               GHepParticle * sp = new GHepParticle(*p);
               sp->SetFirstMother(mom);
+              sp->SetLastMother(-1);  // in case mother had 2 mothers
 	      // this was PreEquilibrium - now just used for hN
 	      //same arguement lists for PreEq and Eq
 	      utils::intranuke2018::Equilibrium(ev,sp,fRemnA,fRemnZ,fRemnP4,

--- a/src/Physics/HadronTransport/HNIntranuke2025.cxx
+++ b/src/Physics/HadronTransport/HNIntranuke2025.cxx
@@ -917,6 +917,7 @@ int HNIntranuke2025::HandleCompoundNucleus(GHepRecord* ev, GHepParticle* p, int 
             {
               GHepParticle * sp = new GHepParticle(*p);
               sp->SetFirstMother(mom);
+              sp->SetLastMother(-1);  // in case mother had 2 mothers
 	      // this was PreEquilibrium - now just used for hN
 	      //same arguement lists for PreEq and Eq
 	      utils::intranuke2025::Equilibrium(ev,sp,fRemnA,fRemnZ,fRemnP4,
@@ -932,6 +933,7 @@ int HNIntranuke2025::HandleCompoundNucleus(GHepRecord* ev, GHepParticle* p, int 
                 << "*** Nothing left to interact with, escaping.";
               GHepParticle * sp = new GHepParticle(*p);
               sp->SetFirstMother(mom);
+              sp->SetLastMother(-1);  // in case mother had 2 mothers
               sp->SetStatus(kIStStableFinalState);
               ev->AddParticle(*sp);
               delete sp;

--- a/src/Physics/HadronTransport/HadronTransporter.cxx
+++ b/src/Physics/HadronTransport/HadronTransporter.cxx
@@ -116,6 +116,7 @@ void HadronTransporter::TransportInTransparentNuc(GHepRecord * evrec) const
     GHepParticle * cp = new GHepParticle(*p); // create a clone
 
     cp->SetFirstMother(icurr);                // clone's mother
+    cp->SetLastMother(-1);                    // in case mother had 2 mothers
     cp->SetStatus(kIStStableFinalState);      // mark it & done with it
 
     evrec->AddParticle(*cp); // add it at the event record

--- a/src/Physics/HadronTransport/INukeDeltaPropg.cxx
+++ b/src/Physics/HadronTransport/INukeDeltaPropg.cxx
@@ -94,6 +94,7 @@ void INukeDeltaPropg::ProcessEventRecord(GHepRecord * event) const
         
     // Set clone's mom to be the hadron that was cloned
     sp->SetFirstMother(icurr);
+    sp->SetLastMother(-1);  // in case mother had 2 mothers
 
     // Start stepping particle out of the nucleus
     bool has_interacted = false;

--- a/src/Physics/HadronTransport/INukeException.cxx
+++ b/src/Physics/HadronTransport/INukeException.cxx
@@ -2,7 +2,6 @@
 /*
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
 
  Costas Andreopoulos <c.andreopoulos \at cern.ch>
  University of Liverpool

--- a/src/Physics/HadronTransport/INukeHadroData.cxx
+++ b/src/Physics/HadronTransport/INukeHadroData.cxx
@@ -2,7 +2,6 @@
 /*
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
 
  Costas Andreopoulos <c.andreopoulos \at cern.ch>, Rutherford Lab.
          Steve Dytman <dytman+@pitt.edu>, Pittsburgh Univ.

--- a/src/Physics/HadronTransport/INukeHadroData2018.cxx
+++ b/src/Physics/HadronTransport/INukeHadroData2018.cxx
@@ -2,7 +2,6 @@
 /*
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
 
  Costas Andreopoulos <c.andreopoulos \at cern.ch>, Rutherford Lab.
          Steve Dytman <dytman+@pitt.edu>, Pittsburgh Univ.

--- a/src/Physics/HadronTransport/INukeHadroData2025.cxx
+++ b/src/Physics/HadronTransport/INukeHadroData2025.cxx
@@ -2,7 +2,6 @@
 /*
  Copyright (c) 2003-2024, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
- 
 
  Costas Andreopoulos <c.andreopoulos \at cern.ch>, Rutherford Lab.
          Steve Dytman <dytman+@pitt.edu>, Pittsburgh Univ.

--- a/src/Physics/HadronTransport/INukeNucleonCorr.cxx
+++ b/src/Physics/HadronTransport/INukeNucleonCorr.cxx
@@ -3,7 +3,6 @@
  Copyright (c) 2003-2025, The GENIE Collaboration
  For the full text of the license visit http://copyright.genie-mc.org
 
-
  Author: Tomek Golan <tomasz.golan@uwr.edu.pl>, FNAL/Rochester
          Steve Dytman <dytman+@pitt.edu>, Pittsburgh Univ.
          Josh Kleckner <jok84@pitt.edu>, Pittsburgh Univ.

--- a/src/Physics/HadronTransport/INukeUtils.cxx
+++ b/src/Physics/HadronTransport/INukeUtils.cxx
@@ -532,6 +532,7 @@ void genie::utils::intranuke::PreEquilibrium(
   // decay a clone particle
   GHepParticle * t = new GHepParticle(*(ev->Particle(f_loc)));
   t->SetFirstMother(f_loc);
+  t->SetLastMother(-1);  // in case mother had 2 mothers
   genie::utils::intranuke::Equilibrium(ev,t,RemnA,RemnZ,RemnP4,DoFermi,FermiFac,Nuclmodel,NucRmvE,mode);
 
   delete t;

--- a/src/Physics/HadronTransport/INukeUtils2018.cxx
+++ b/src/Physics/HadronTransport/INukeUtils2018.cxx
@@ -631,6 +631,7 @@ void genie::utils::intranuke2018::PreEquilibrium(
   // decay a clone particle
   GHepParticle * t = new GHepParticle(*(ev->Particle(f_loc)));
   t->SetFirstMother(f_loc);
+  t->SetLastMother(-1);  // in case mother had 2 mothers
   //next statement was in Alex Bell's original code - PreEq, then Equilibrium using particle with highest energy.  Note it gets IST=kIStIntermediateState.
   //genie::utils::intranuke2018::Equilibrium(ev,t,RemnA,RemnZ,RemnP4,DoFermi,FermiFac,Nuclmodel,NucRmvE,mode);
 

--- a/src/Physics/HadronTransport/INukeUtils2025.cxx
+++ b/src/Physics/HadronTransport/INukeUtils2025.cxx
@@ -616,6 +616,7 @@ void genie::utils::intranuke2025::PreEquilibrium(
   // decay a clone particle
   GHepParticle * t = new GHepParticle(*(ev->Particle(f_loc)));
   t->SetFirstMother(f_loc);
+  t->SetLastMother(-1);  // in case mother had 2 mothers
   //next statement was in Alex Bell's original code - PreEq, then Equilibrium using particle with highest energy.  Note it gets IST=kIStIntermediateState.
   //genie::utils::intranuke2025::Equilibrium(ev,t,RemnA,RemnZ,RemnP4,DoFermi,FermiFac,Nuclmodel,NucRmvE,mode);
 

--- a/src/Physics/HadronTransport/Intranuke.cxx
+++ b/src/Physics/HadronTransport/Intranuke.cxx
@@ -319,7 +319,8 @@ void Intranuke::TransportHadrons(GHepRecord * evrec) const
     GHepParticle * sp = new GHepParticle(*p); 
 
     // Set clone's mom to be the hadron that was cloned
-    sp->SetFirstMother(icurr); 
+    sp->SetFirstMother(icurr);
+    sp->SetLastMother(-1);  // in case mother had 2 mothers
 
     // Check whether the particle can be rescattered 
     if(!this->CanRescatter(sp)) {

--- a/src/Physics/HadronTransport/Intranuke2018.cxx
+++ b/src/Physics/HadronTransport/Intranuke2018.cxx
@@ -320,6 +320,7 @@ void Intranuke2018::TransportHadrons(GHepRecord * evrec) const
 
     // Set clone's mom to be the hadron that was cloned
     sp->SetFirstMother(icurr);
+    sp->SetLastMother(-1);  // in case mother had 2 mothers
 
     // Check whether the particle can be rescattered
     if(!this->CanRescatter(sp)) {
@@ -328,6 +329,7 @@ void Intranuke2018::TransportHadrons(GHepRecord * evrec) const
        LOG("Intranuke2018", pNOTICE)
               << "... Current version can't rescatter a " << sp->Name();
        sp->SetFirstMother(icurr);
+       sp->SetLastMother(-1);  // in case mother had 2 mothers
        sp->SetStatus(kIStStableFinalState);
        evrec->AddParticle(*sp);
        delete sp;

--- a/src/Physics/HadronTransport/Intranuke2025.cxx
+++ b/src/Physics/HadronTransport/Intranuke2025.cxx
@@ -284,6 +284,7 @@ void Intranuke2025::TransportHadrons(GHepRecord * evrec) const
 
     // Set clone's mom to be the hadron that was cloned
     sp->SetFirstMother(icurr);
+    sp->SetLastMother(-1);  // in case mother had 2 mothers
 
     // Check whether the particle can be rescattered
     if(!this->CanRescatter(sp)) {
@@ -292,6 +293,7 @@ void Intranuke2025::TransportHadrons(GHepRecord * evrec) const
        LOG("Intranuke2025", pNOTICE)
               << "... Current version can't rescatter a " << sp->Name();
        sp->SetFirstMother(icurr);
+       sp->SetLastMother(-1);  // in case mother had 2 mothers
        sp->SetStatus(kIStStableFinalState);
        evrec->AddParticle(*sp);
        delete sp;

--- a/src/Physics/HadronTransport/NucBindEnergyAggregator.cxx
+++ b/src/Physics/HadronTransport/NucBindEnergyAggregator.cxx
@@ -185,7 +185,7 @@ GHepParticle * NucBindEnergyAggregator::FindMotherNucleus(
   //-- get its mothet
   int mother_pos = p->FirstMother();
 
-  //-- in case mother is set
+  //-- if mother is set
   if(mother_pos != -1) {
      GHepParticle * mother = evrec->Particle(mother_pos);
 

--- a/src/Physics/HadronTransport/NucBindEnergyAggregator.cxx
+++ b/src/Physics/HadronTransport/NucBindEnergyAggregator.cxx
@@ -185,7 +185,7 @@ GHepParticle * NucBindEnergyAggregator::FindMotherNucleus(
   //-- get its mothet
   int mother_pos = p->FirstMother();
 
-  //-- if mother is set
+  //-- in case mother is set
   if(mother_pos != -1) {
      GHepParticle * mother = evrec->Particle(mother_pos);
 


### PR DESCRIPTION
  Traditionally community spline files go up to 1000 GeV.  I've previously seen some cross-section evaluations set to 0 at 1000 GeV.  This messes up the TSpline3 evaluation for the last three energy points because it has to take a sharp turn over to hit the zero at that last knot.  
  
 I surmise that these zero xsec values where due to the algorithm doing a `epoint >= emax` test, but I could never find it in the code.  As an alternative we'll change all instances of `GVLD-Emax` set to `1000.000` in any `CommonParam.xml `file to `1000.010` to hopefully avoid this issue.